### PR TITLE
chore: update to node-opcua 2.175

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,19 @@
       "license": "ISC",
       "dependencies": {
         "chalk": "^4.1.2",
-        "node-opcua": "~2.63.2",
-        "node-opcua-crypto": "~1.7.5",
+        "node-opcua": "^2.175.1",
+        "node-opcua-address-space-for-conformance-testing": "^2.175.1",
+        "node-opcua-crypto": "^5.3.6",
         "ws": "^8.4.2"
       },
       "bin": {
         "wsopcua-test-server": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^17.0.14",
-        "@types/ws": "^7.2.7",
+        "@types/node": "^20.0.0",
+        "@types/ws": "^8.5.0",
         "semantic-release": "^25.0.3",
-        "typescript": "^4.5.5"
+        "typescript": "^5.6.0"
       }
     },
     "node_modules/@actions/core": {
@@ -108,6 +109,12 @@
       "engines": {
         "node": ">=0.1.90"
       }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
     },
     "node_modules/@octokit/auth-token": {
       "version": "6.0.0",
@@ -264,6 +271,190 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.7.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+      "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "tslib": "^2.8.1",
+        "webcrypto-core": "^1.9.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "2.0.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/x509/-/x509-2.0.0.tgz",
+      "integrity": "sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -589,13 +780,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "0.14.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -610,44 +794,46 @@
       }
     },
     "node_modules/@ster5/global-mutex": {
-      "version": "1.2.0",
-      "license": "MIT"
-    },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "1.1.2",
+      "version": "3.3.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@ster5/global-mutex/-/global-mutex-3.3.0.tgz",
+      "integrity": "sha512-uiGJTiE0ZiQ6z9VMOHVT3RNrErCi3pZh1bGbfb27GAXCAsvCyLz61pLfBYq8uzsf6Y2qdybhoTwHy7UGtK6MYw==",
       "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^1.0.1"
-      },
       "engines": {
-        "node": ">=6"
+        "node": ">=20"
+      },
+      "peerDependenciesMeta": {
+        "proper-lockfile": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@types/async": {
-      "version": "3.2.12",
-      "license": "MIT"
-    },
-    "node_modules/@types/bonjour": {
-      "version": "3.5.10",
+    "node_modules/@types/dns-packet": {
+      "version": "5.6.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@types/dns-packet/-/dns-packet-5.6.5.tgz",
+      "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.178",
-      "license": "MIT"
-    },
-    "node_modules/@types/mkdirp": {
-      "version": "1.0.1",
+    "node_modules/@types/multicast-dns": {
+      "version": "7.2.4",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@types/multicast-dns/-/multicast-dns-7.2.4.tgz",
+      "integrity": "sha512-ib5K4cIDR4Ro5SR3Sx/LROkMDa0BHz0OPaCBL/OSPDsAXEGZ3/KQeS6poBKYVN7BfjXDL9lWNwzyHVgt/wkyCw==",
       "license": "MIT",
       "dependencies": {
+        "@types/dns-packet": "*",
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.14",
-      "license": "MIT"
+      "version": "20.19.43",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -656,19 +842,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/once": {
-      "version": "1.4.0",
-      "license": "MIT"
-    },
-    "node_modules/@types/underscore": {
-      "version": "1.11.4",
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
-      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "version": "8.18.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -700,14 +885,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-align": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "dependencies": {
-        "string-width": "^4.1.0"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -726,6 +903,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -746,19 +924,8 @@
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -772,8 +939,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "2.1.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/array-flatten/-/array-flatten-2.1.2.tgz",
+      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
       "license": "MIT"
     },
     "node_modules/array-ify": {
@@ -785,27 +963,41 @@
     },
     "node_modules/asn1": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.3",
-      "license": "MIT"
-    },
     "node_modules/backoff": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==",
+      "license": "MIT",
       "dependencies": {
         "precond": "0.2"
       },
@@ -815,8 +1007,9 @@
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -828,39 +1021,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/better-assert": {
-      "version": "1.0.2",
-      "dependencies": {
-        "callsite": "1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/bomstrip": {
-      "version": "0.1.4",
-      "license": "MIT"
-    },
-    "node_modules/bonjour": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
-      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
-      "dependencies": {
-        "array-flatten": "^2.1.0",
-        "deep-equal": "^1.0.1",
-        "dns-equal": "^1.0.0",
-        "dns-txt": "^2.0.2",
-        "multicast-dns": "^6.0.1",
-        "multicast-dns-service-types": "^1.1.0"
-      }
-    },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -868,42 +1028,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/boxen": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
-      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
-      "dependencies": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.1.0",
-        "cli-boxes": "^2.2.1",
-        "string-width": "^4.2.2",
-        "type-fest": "^0.20.2",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -912,43 +1041,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/buffer-indexof": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
     "node_modules/byline": {
       "version": "5.0.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/callbackify": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
-    "node_modules/callsite": {
-      "version": "1.0.0",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/callsites": {
@@ -959,16 +1058,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "6.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chalk": {
@@ -986,6 +1075,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -997,34 +1101,19 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "4.0.3",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 14.16.0"
       },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/ci-info": {
-      "version": "2.0.0",
-      "license": "MIT"
     },
     "node_modules/clean-stack": {
       "version": "5.3.0",
@@ -1050,16 +1139,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-boxes": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1106,15 +1185,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cli-table": {
-      "version": "0.3.11",
-      "dependencies": {
-        "colors": "1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.2.0"
-      }
-    },
     "node_modules/cli-table3": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
@@ -1135,17 +1205,11 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/clone-response": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
       }
     },
     "node_modules/color-convert": {
@@ -1162,11 +1226,42 @@
       "version": "1.1.4",
       "license": "MIT"
     },
-    "node_modules/colors": {
-      "version": "1.0.3",
+    "node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
       "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
       "engines": {
-        "node": ">=0.1.90"
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/compare-func": {
@@ -1197,22 +1292,6 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/configstore": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/conventional-changelog-angular": {
       "version": "8.3.1",
@@ -1307,15 +1386,10 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dashdash": {
       "version": "1.14.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
@@ -1342,60 +1416,18 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dependencies": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
       }
     },
-    "node_modules/defer-to-connect": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dependencies": {
-        "object-keys": "^1.0.12"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/delayed": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
     "node_modules/dequeue": {
       "version": "1.0.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/dequeue/-/dequeue-1.0.5.tgz",
+      "integrity": "sha512-2FIVJZTaWhUj0Y2uKmDAasTP6ZwFWRjkRc01MYN5jFm96iIzkYyNzGADfJ13C5W7CTN7XO9mBYDcVB68eNybBA==",
       "engines": {
         "node": "*"
       }
@@ -1415,26 +1447,25 @@
     },
     "node_modules/dns-equal": {
       "version": "1.0.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/dns-equal/-/dns-equal-1.0.0.tgz",
+      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
       "license": "MIT"
     },
     "node_modules/dns-packet": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
-      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
-      "dependencies": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/dns-txt": {
-      "version": "2.0.2",
+      "version": "5.6.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
       "license": "MIT",
       "dependencies": {
-        "buffer-indexof": "^1.0.0"
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-obj": "^2.0.0"
@@ -1443,14 +1474,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/duplexer3": {
-      "version": "0.1.4",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -1458,6 +1486,7 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emojilib": {
@@ -1466,14 +1495,6 @@
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
     },
     "node_modules/env-ci": {
       "version": "11.2.0",
@@ -1634,16 +1655,10 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-goat": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1728,13 +1743,11 @@
       ],
       "license": "MIT"
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "6.1.0",
@@ -1756,12 +1769,30 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/find-up-simple": {
@@ -1820,23 +1851,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "license": "MIT"
-    },
     "node_modules/function-timeout": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
@@ -1852,6 +1866,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -1870,18 +1885,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -1897,107 +1900,16 @@
     },
     "node_modules/getpass": {
       "version": "0.1.7",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
     },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/global-dirs": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ini": "2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/got": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-      "dependencies": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/got/node_modules/cacheable-request": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/got/node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/got/node_modules/cacheable-request/node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/got/node_modules/get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/handlebars": {
@@ -2022,16 +1934,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "license": "MIT",
@@ -2039,41 +1941,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-yarn": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/hexy": {
-      "version": "0.3.2",
+      "version": "0.4.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/hexy/-/hexy-0.4.0.tgz",
+      "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
       "license": "MIT",
       "bin": {
         "hexy": "bin/hexy_cmd.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/highlight.js": {
@@ -2111,10 +1988,6 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -2156,6 +2029,8 @@
     },
     "node_modules/humanize": {
       "version": "0.0.9",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/humanize/-/humanize-0.0.9.tgz",
+      "integrity": "sha512-bvZZ7vXpr1RKoImjuQ45hJb5OvE2oJafHysiD/AL3nkqTZH2hFCjQ3YZfCd63FefDitbJze/ispUPP0gfDsT2Q==",
       "engines": {
         "node": "*"
       }
@@ -2201,13 +2076,6 @@
         "node": ">=18.20"
       }
     },
-    "node_modules/import-lazy": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
@@ -2217,13 +2085,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -2257,13 +2118,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/ini": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/into-stream": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
@@ -2281,114 +2135,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ip": {
-      "version": "1.1.5",
-      "license": "MIT"
-    },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-ci": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^2.0.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-installed-globally": {
-      "version": "0.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "global-dirs": "^3.0.0",
-        "is-path-inside": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-npm": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -2396,13 +2160,7 @@
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2421,20 +2179,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-regex": {
-      "version": "1.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
@@ -2448,10 +2192,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -2464,10 +2204,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-yarn-global": {
-      "version": "0.3.0",
-      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -2530,10 +2266,8 @@
     },
     "node_modules/jsbn": {
       "version": "0.1.1",
-      "license": "MIT"
-    },
-    "node_modules/json-buffer": {
-      "version": "3.0.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
@@ -2569,31 +2303,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsrsasign": {
-      "version": "10.5.1",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/kjur/jsrsasign#donations"
-      }
-    },
-    "node_modules/keyv": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.0"
-      }
-    },
-    "node_modules/latest-version": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
-      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-      "dependencies": {
-        "package-json": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -2601,15 +2310,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "license": "MIT"
-    },
     "node_modules/lodash-es": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/lodash.capitalize": {
@@ -2640,6 +2351,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.partition": {
+      "version": "4.6.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/lodash.partition/-/lodash.partition-4.6.0.tgz",
+      "integrity": "sha512-35L3dSF3Q6V1w5j6V3NhNlQjzsRDC/pYKCTdYTmwqSib+Q8ponkAmt/PwEOq3EmI38DSCl+SkIVwLd+uSlVdrg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
@@ -2648,15 +2371,10 @@
       "license": "MIT"
     },
     "node_modules/long": {
-      "version": "4.0.0",
+      "version": "5.3.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
-    },
-    "node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/lru-cache": {
       "version": "11.3.5",
@@ -2666,13 +2384,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/ltx": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.4.0"
       }
     },
     "node_modules/make-asynchronous": {
@@ -2704,26 +2415,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/marked": {
@@ -2850,26 +2541,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.5",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2879,20 +2554,17 @@
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
-      "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+      "version": "7.2.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "license": "MIT",
       "dependencies": {
-        "dns-packet": "^1.3.1",
+        "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
       },
       "bin": {
         "multicast-dns": "cli.js"
       }
-    },
-    "node_modules/multicast-dns-service-types": {
-      "version": "1.1.0",
-      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -2950,1205 +2622,1048 @@
       }
     },
     "node_modules/node-opcua": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua/-/node-opcua-2.63.2.tgz",
-      "integrity": "sha512-kCbnm8y/S6LpIwjW4KPJu1CDTysNJRFgAPg18cZK30Yuu1hRpbuGg/knHVXaZQFPzzfNXCPkjVXxDVkD8LpdfQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua/-/node-opcua-2.175.1.tgz",
+      "integrity": "sha512-C8uVa3hzBhbu4l5SNYdpbG6ahoJmoUN/Ql+MWZI902KCSh60fsErg3KqOgWs30Lni3qU9441h/gmVnqtRTNgpQ==",
+      "license": "MIT",
       "dependencies": {
+        "@types/semver": "7.7.1",
         "chalk": "4.1.2",
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-address-space-for-conformance-testing": "2.63.2",
-        "node-opcua-aggregates": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-certificate-manager": "2.63.2",
-        "node-opcua-client": "2.63.2",
-        "node-opcua-client-crawler": "2.63.2",
-        "node-opcua-client-proxy": "2.63.2",
-        "node-opcua-common": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-data-access": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-hostname": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-nodesets": "2.63.0",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-packet-analyzer": "2.63.2",
-        "node-opcua-secure-channel": "2.63.2",
-        "node-opcua-server": "2.63.2",
-        "node-opcua-server-discovery": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-discovery": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-service-node-management": "2.63.2",
-        "node-opcua-service-query": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-register-node": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-service-session": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-transport": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "node-opcua-vendor-diagnostic": "2.63.2",
-        "semver": "^7.3.5"
+        "node-opcua-address-space": "2.175.1",
+        "node-opcua-address-space-for-conformance-testing": "2.175.1",
+        "node-opcua-aggregates": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-certificate-manager": "2.175.1",
+        "node-opcua-client": "2.175.1",
+        "node-opcua-client-proxy": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-data-access": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-hostname": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-nodesets": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-packet-analyzer": "2.175.1",
+        "node-opcua-secure-channel": "2.175.1",
+        "node-opcua-server": "2.175.1",
+        "node-opcua-server-discovery": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-discovery": "2.175.1",
+        "node-opcua-service-endpoints": "2.175.1",
+        "node-opcua-service-filter": "2.175.1",
+        "node-opcua-service-history": "2.175.1",
+        "node-opcua-service-node-management": "2.175.1",
+        "node-opcua-service-query": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-register-node": "2.175.1",
+        "node-opcua-service-secure-channel": "2.175.1",
+        "node-opcua-service-session": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-transport": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1",
+        "node-opcua-vendor-diagnostic": "2.175.1",
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": ">=8.10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/erossignon"
       }
     },
     "node_modules/node-opcua-address-space": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-address-space/-/node-opcua-address-space-2.63.2.tgz",
-      "integrity": "sha512-2DWeyjt9QANYUnxOdK0qUSRmExJNTO+VcCrTqYBsM+F+KZXDBTgRYojICXLBeCE1VfTPsQEu17JmTdoqNN6KrQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-address-space/-/node-opcua-address-space-2.175.1.tgz",
+      "integrity": "sha512-EtNR9H56OX5E85wFT7Du/aCXLYc8pjcY74IMSajINtQHw2YqxvVTtnxBYJyt9fE7uGj4DlP2q9aKEwwcFP4Y0w==",
+      "license": "MIT",
       "dependencies": {
-        "@types/lodash": "4.14.178",
-        "async": "^3.2.3",
+        "@types/semver": "7.7.1",
         "chalk": "4.1.2",
         "dequeue": "^1.0.5",
-        "lodash": "4.17.21",
-        "node-opcua-address-space-base": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-client-dynamic-extension-object": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-access": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-nodeset-ua": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pseudo-session": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "node-opcua-xml2json": "2.63.2",
-        "set-prototype-of": "^1.0.0",
-        "thenify": "^3.3.1",
+        "node-opcua-address-space-base": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-client-dynamic-extension-object": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-data-access": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-nodeset-ua": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-pseudo-session": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-history": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1",
+        "node-opcua-xml2json": "2.175.1",
+        "semver": "^7.8.5",
+        "thenify-ex": "4.4.0",
         "xml-writer": "^1.7.0"
       },
       "engines": {
-        "node": ">=6.10"
+        "node": ">=18"
       }
     },
     "node_modules/node-opcua-address-space-base": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-address-space-base/-/node-opcua-address-space-base-2.63.2.tgz",
-      "integrity": "sha512-1YmCn0Hb00/iH0uW1vf5dKM7OPUYMxZemminZkK/C8PlMSeUjE7WMEnBKr/3wpf9dSMAwBcXYuIxIjrlokZJqw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-address-space-base/-/node-opcua-address-space-base-2.175.1.tgz",
+      "integrity": "sha512-3SCIBjJVQNpB9EqPfb+qo5U60aMAwbSrC2Tp0Kh+Qrgvm5kCWKdjvKnr8NHG7Y1fQiVXGDm3tib8BB5K83mGwQ==",
+      "license": "MIT",
       "dependencies": {
-        "@types/lodash": "4.14.178",
-        "async": "^3.2.3",
-        "chalk": "4.1.2",
-        "dequeue": "^1.0.5",
-        "lodash": "4.17.21",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-client-dynamic-extension-object": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-access": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pseudo-session": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "node-opcua-xml2json": "2.63.2",
-        "set-prototype-of": "^1.0.0",
-        "thenify": "^3.3.1",
-        "xml-writer": "^1.7.0"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-schemas": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       },
       "engines": {
-        "node": ">=6.10"
+        "node": ">=18"
       }
     },
     "node_modules/node-opcua-address-space-for-conformance-testing": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-address-space-for-conformance-testing/-/node-opcua-address-space-for-conformance-testing-2.63.2.tgz",
-      "integrity": "sha512-H/7q2LmGny5EiRLZWgHdbZ8xR/nMQopgNIHQIfwTHGAaPlO+ITEu8tDZ/IdVjHq63o9NcF6N29yZoJ/tV962bA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-address-space-for-conformance-testing/-/node-opcua-address-space-for-conformance-testing-2.175.1.tgz",
+      "integrity": "sha512-MQpt0L39jbCQgTRD5tpfBD2PneDz8RTzgg9DrojKLKO339cc29CsmZVQnmrDh4v26VfXjlWlL4BGOwDM95NZXQ==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-data-access": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-address-space": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-data-access": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-aggregates": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-aggregates/-/node-opcua-aggregates-2.63.2.tgz",
-      "integrity": "sha512-qhTQvaQLMHWiC0Jk/OpnfgdQibCj8n2GwpGmbPvscD77dPjRJzJYzMtPUwWlIHXsuVKxewfGzW7PidjoGH1nZA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-aggregates/-/node-opcua-aggregates-2.175.1.tgz",
+      "integrity": "sha512-438V0nqU2JJOrN8EVlzZQWQ55okDy3MlCRflfOHpQ8LWOKmrtjf1jdf4v6j0XC0UnomvxA997WghWpaJntMPFQ==",
+      "license": "MIT",
       "dependencies": {
-        "@types/async": "^3.2.12",
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-nodesets": "2.63.0",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-address-space": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-server": "2.175.1",
+        "node-opcua-service-history": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1"
+      }
+    },
+    "node_modules/node-opcua-alarm-condition": {
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-alarm-condition/-/node-opcua-alarm-condition-2.175.1.tgz",
+      "integrity": "sha512-UvP+3qQP3gosSfQpc1nNCU/9MFH9iKj095Yq4FBuzanNFsI+967DV+zaJ+eTV6M9j+l9F5h8PVc5eE2EaXr3aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-pseudo-session": "2.175.1",
+        "node-opcua-service-filter": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-assert": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-assert/-/node-opcua-assert-2.63.0.tgz",
-      "integrity": "sha512-ZyiaiumumUtiXr82FsjrO1reP/Nf487Mztoz4CZ6X+wVSHQywXb8YUKsTAv3e0cAzjPK6mwXneALxxtCVWANVA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-assert/-/node-opcua-assert-2.175.1.tgz",
+      "integrity": "sha512-xSHHApbeJW1IhRKDUwSac0S00zfOuWsiMpTfCXU5IZiE4bzWTOV82VFVv9jA+mt5nklb/t60+VxjhwJWxDO+hg==",
+      "license": "MIT",
       "dependencies": {
-        "better-assert": "^1.0.2",
         "chalk": "4.1.2"
       }
     },
     "node_modules/node-opcua-basic-types": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-basic-types/-/node-opcua-basic-types-2.63.2.tgz",
-      "integrity": "sha512-G5FtBhCREIn1k3xuxczTh18U8QT6dzt8AU8SQwmBCWmtK6XPlrZm3L5QF2o+hI0nxYniHRxa9ygKC02fSuansQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-basic-types/-/node-opcua-basic-types-2.175.1.tgz",
+      "integrity": "sha512-OkiWY8jpknBANBA+K1zZ+sOc8o0mGTsP+eAplZMdiP7Jav5YQS6cI92/Y/0plfpHUQuPXFxzdTceDeM38OZodA==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-guid": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-buffer-utils": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-guid": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-status-code": "2.175.1"
       }
     },
     "node_modules/node-opcua-binary-stream": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-binary-stream/-/node-opcua-binary-stream-2.63.2.tgz",
-      "integrity": "sha512-Y5oJI53L9UXwuxB2RSNBtL5kMb/gFW/WbCiQaF6B4+0z3rlMjEVLaPGP3sIJYE1EfsNnecar2CotKRoO+/ur0w==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-binary-stream/-/node-opcua-binary-stream-2.175.1.tgz",
+      "integrity": "sha512-OORZZs6bg5RUMffhRUBDD4tZRWamCMCP1Olf/Y/k7GHvpT5RVwaHHYxDIWg8zng/0UxGyWktE6u2aleMyXG7sg==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-buffer-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-buffer-utils": "2.175.1"
       }
     },
     "node_modules/node-opcua-buffer-utils": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-buffer-utils/-/node-opcua-buffer-utils-2.63.2.tgz",
-      "integrity": "sha512-yi4mbZEmc9fbFUaIiGu3BlTLlgCrYmVI+WjGfjrY8ZcyvX/2ssFm3WJQn0k6JfyQYqNcf7CsNOfKHAymS/nl8Q==",
-      "dependencies": {
-        "node-opcua-assert": "2.63.0"
-      }
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-buffer-utils/-/node-opcua-buffer-utils-2.175.1.tgz",
+      "integrity": "sha512-j0fQ7zJaw7bbxylo6syU1+6KJVD/dshIQYNJmR3z3uy7q7M7xnpinHRkdJU3bBCJk4tURjHorIFIZUzN0qt3Jg==",
+      "license": "MIT"
     },
     "node_modules/node-opcua-certificate-manager": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-certificate-manager/-/node-opcua-certificate-manager-2.63.2.tgz",
-      "integrity": "sha512-diRpWwh4VefASCMvS06H1bXpB/QOAUu7vfk/YRrm5hLDrgL9RkLwQ5QPkQqmDkk78046bp3TH15J4KDg1MC9zw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-certificate-manager/-/node-opcua-certificate-manager-2.175.1.tgz",
+      "integrity": "sha512-u+MUjzQVX+lim/COQgYgpI6LyVOJt+GUZkN7Sdx1zvfaxEZ3Iu0yV0+FLnCe4zSPwz5aCtuYPQpn819tVuw4Cw==",
+      "license": "MIT",
       "dependencies": {
-        "@types/mkdirp": "1.0.1",
-        "chalk": "4.1.2",
-        "delayed": "^2.0.0",
         "env-paths": "2.2.1",
-        "mkdirp": "1.0.4",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pki": "^2.13.0",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "once": "^1.4.0",
-        "thenify": "^3.3.1"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-pki": "6.18.0",
+        "node-opcua-status-code": "2.175.1",
+        "thenify-ex": "4.4.0"
       }
     },
     "node_modules/node-opcua-chunkmanager": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-chunkmanager/-/node-opcua-chunkmanager-2.63.2.tgz",
-      "integrity": "sha512-aHRXmd6ibsxxqdZetDhvYCv9fEf8xL+U2V98J6NFawcMl644XX5g3TQGOXDf031Yt4sGQM9+DeDcENbgXk6kzA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-chunkmanager/-/node-opcua-chunkmanager-2.175.1.tgz",
+      "integrity": "sha512-3mfvJMPIfnFF0pL9flo2gGrU3sS1YuKaHFGdNEvi7iCaqebcVp+IoZJ0BfJW1S793jM78O4kV/kmFitCEHQfDw==",
+      "license": "MIT",
       "dependencies": {
-        "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-packet-assembler": "2.63.0"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-buffer-utils": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-packet-assembler": "2.175.1"
       }
     },
     "node_modules/node-opcua-client": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-client/-/node-opcua-client-2.63.2.tgz",
-      "integrity": "sha512-oS/T8gZs5GpSlpSjOHR9bFThMql861Li87tvq3MdGhcIcRrzQWSRgmCsdb3sAOzxLXR6JFIAH0ffNp/SX0DZqA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-client/-/node-opcua-client-2.175.1.tgz",
+      "integrity": "sha512-fXrsFe2lK9sFIH0HdE0EGQg1PgzhG/V6f1abVun03XZbj8sb2flwNYZrr0fkqzx3MuZLDVZjtzTt3mnu7XQZkA==",
+      "license": "MIT",
       "dependencies": {
-        "@ster5/global-mutex": "^1.2.0",
-        "@types/async": "^3.2.12",
-        "@types/once": "^1.4.0",
-        "@types/underscore": "^1.11.4",
-        "async": "^3.2.3",
-        "callbackify": "^1.1.0",
+        "@ster5/global-mutex": "^3.3.0",
         "chalk": "4.1.2",
-        "delayed": "^2.0.0",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-certificate-manager": "2.63.2",
-        "node-opcua-client-dynamic-extension-object": "2.63.2",
-        "node-opcua-common": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-hostname": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pki": "^2.13.0",
-        "node-opcua-pseudo-session": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-secure-channel": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-discovery": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-service-query": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-register-node": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-service-session": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "once": "^1.4.0",
-        "thenify": "^3.3.1",
-        "underscore": "^1.13.2"
-      }
-    },
-    "node_modules/node-opcua-client-crawler": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-client-crawler/-/node-opcua-client-crawler-2.63.2.tgz",
-      "integrity": "sha512-q/47BmNc0hgCOakYaDgM1AvWd02H7/SDS71SJtXcOX8pUIDtV5CboeWWYaR473fJJDLRSHMC8DaRwanfiqTo7Q==",
-      "dependencies": {
-        "@types/underscore": "^1.11.4",
-        "async": "^3.2.3",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "underscore": "^1.13.2"
+        "node-opcua-alarm-condition": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-buffer-utils": "2.175.1",
+        "node-opcua-certificate-manager": "2.175.1",
+        "node-opcua-client-dynamic-extension-object": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-hostname": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-pki": "6.18.0",
+        "node-opcua-pseudo-session": "2.175.1",
+        "node-opcua-schemas": "2.175.1",
+        "node-opcua-secure-channel": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-discovery": "2.175.1",
+        "node-opcua-service-endpoints": "2.175.1",
+        "node-opcua-service-filter": "2.175.1",
+        "node-opcua-service-history": "2.175.1",
+        "node-opcua-service-query": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-register-node": "2.175.1",
+        "node-opcua-service-secure-channel": "2.175.1",
+        "node-opcua-service-session": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-transport": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1",
+        "thenify-ex": "4.4.0"
       }
     },
     "node_modules/node-opcua-client-dynamic-extension-object": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-client-dynamic-extension-object/-/node-opcua-client-dynamic-extension-object-2.63.2.tgz",
-      "integrity": "sha512-wFcQuc5x9pMB7lY/mydXNp9zrFryslr8UW4xzqwcy+nP9sKWgKrHGCDqso3zKks8IrQ24wzxm/B1/hvlhupb5g==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-client-dynamic-extension-object/-/node-opcua-client-dynamic-extension-object-2.175.1.tgz",
+      "integrity": "sha512-jtGfH0HaTKxSGRUNR0DVvJwddUOY3VYNbxAFKbAvWaDliA+pO0sbPl++V19SMVo9ahbPcRz/LLxeeoqZmDi5QQ==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-pseudo-session": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-pseudo-session": "2.175.1",
+        "node-opcua-schemas": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-client-proxy": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-client-proxy/-/node-opcua-client-proxy-2.63.2.tgz",
-      "integrity": "sha512-fxPHiRXSW+bg2affcc+rfNQjV2Oca9zz+iLqa17MpHTW4hNFxPKxVfsW6banSo8n0TNPOpbC6kETee34WWebAQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-client-proxy/-/node-opcua-client-proxy-2.175.1.tgz",
+      "integrity": "sha512-+Fge1kFcTERAYyhCb+A1VoWxLGB463uA8tIoKdwPaDNHHqcVwMWqCk3N6WIMPFRbvASB79WvaHxk8U6uArv/TQ==",
+      "license": "MIT",
       "dependencies": {
-        "async": "^3.2.3",
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-pseudo-session": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-pseudo-session": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-common": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-common/-/node-opcua-common-2.63.2.tgz",
-      "integrity": "sha512-QX+MSOF1e4sg49Ct/cd0zXE2nUgMxgsPRQNEW12L7Rs2kglYaNXi6U7YtINET2KNtx1vqZiTB19j5TFv0Xe63w==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-common/-/node-opcua-common-2.175.1.tgz",
+      "integrity": "sha512-/pfuBAeN/BCawJ7eSsQQOBeD6sS4eEng9234edqzYcQusN3juXGsyARdUpiE2y19NB7X8sn9FklAQiVYLjGP8g==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-constants": {
-      "version": "2.62.7",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-constants/-/node-opcua-constants-2.175.1.tgz",
+      "integrity": "sha512-o3icxyhe18cWRWefAa39saAYaPkPx/UmscFOOoZXX37BLcNiH7WNmfJ1T89rdtkDfVqkLXKWyh5ObzOKSohSig==",
       "license": "MIT"
     },
     "node_modules/node-opcua-crypto": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/node-opcua-crypto/-/node-opcua-crypto-1.7.5.tgz",
-      "integrity": "sha512-4JBgUEV0pV5QaFmLVCr22JRGLLJ1rwPSNcKolD7OBOrdmG2OAqD/gsLojAYKeh/nuowv4Sx93j9NZ3pfBzaqrQ==",
-      "dependencies": {
-        "better-assert": "^1.0.2",
-        "chalk": "^4.1.2",
-        "hexy": "0.3.1",
-        "jsrsasign": "^10.4.0",
-        "sshpk": "^1.16.1"
-      }
-    },
-    "node_modules/node-opcua-crypto/node_modules/hexy": {
-      "version": "0.3.1",
+      "version": "5.3.6",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-crypto/-/node-opcua-crypto-5.3.6.tgz",
+      "integrity": "sha512-XXfdMZhXgN8Epf2tJLpQ1a2v/AKa/E+qvaaFXt1wP5ElL1ImU0vs+qxvY3j+Bemz/aob6aelHVrNq1eVU2Fqng==",
       "license": "MIT",
-      "bin": {
-        "hexy": "bin/hexy_cmd.js"
+      "dependencies": {
+        "@peculiar/webcrypto": "^1.7.1",
+        "@peculiar/x509": "^2.0.0",
+        "reflect-metadata": "^0.2.2",
+        "sshpk": "^1.18.0"
       }
     },
     "node_modules/node-opcua-data-access": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-data-access/-/node-opcua-data-access-2.63.2.tgz",
-      "integrity": "sha512-SsVRma+5rWFzF4XFWjlQ12F+XTlVgG3qKLc4tSq3F5QWT8Ts4uY4V4y+hNz8AE2SGa9Wn1IxY8lVVvYJJJV5cg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-data-access/-/node-opcua-data-access-2.175.1.tgz",
+      "integrity": "sha512-Y2trw/Wal0TboNipmeJ9VWr5p8xNHGAP1HnWks/mdoyqKcNNNc9Alz0w1/Rpevm5fX/1Si7Wp+S4iQspHZJJ3A==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-data-model": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-data-model/-/node-opcua-data-model-2.63.2.tgz",
-      "integrity": "sha512-xFi42EEZRLkXDxA2Y/oFtf2n2Vqk6Ek38e22Mrd6ZLykNgp7omyOw9Nb6BuY+ef6ne8JSPEokaePmryzEBOkYQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-data-model/-/node-opcua-data-model-2.175.1.tgz",
+      "integrity": "sha512-cCjorTjSH3iC9zE8LOb1pyRcl5UEn6bpnzn80VMr5CcLh7uCd+6stgol9Nkr7NglXghWtTqoqyeka69qVUwC8Q==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-status-code": "2.175.1"
       }
     },
     "node_modules/node-opcua-data-value": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-data-value/-/node-opcua-data-value-2.63.2.tgz",
-      "integrity": "sha512-vmzkEFoQCNBXGMPHepCorA8Xl2Z4N9FweVFhTJupHaTeVgSgnVNkUn8nY0JB2rpDr/ZnduS/JyVghip2nPq4/A==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-data-value/-/node-opcua-data-value-2.175.1.tgz",
+      "integrity": "sha512-9tkQwc/I/HOyJWIB9j23PsTkuqHkV5DZymllw3oz/lNhYPPwEucS9LBwqUaJSodo69YNWTA1yz16aHqgbrJn7A==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-date-time": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-date-time/-/node-opcua-date-time-2.63.2.tgz",
-      "integrity": "sha512-8xGOJ/drfLXmP4ozYm4rYc1+kKOev/uT9NQzAnVah3s9ZCBuQkEkONZ29Hipj+GDwLJ8RfvvjbT6YtrYIb/ZHA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-date-time/-/node-opcua-date-time-2.175.1.tgz",
+      "integrity": "sha512-ngj2T6NA3ZufMxZcPyoHsNOCvS0wBx/VXVf0qjcrHFF9d/rAoCrAWJ5lhvzq8wN9RVXzqQ9XspdAo4bawKOFNA==",
+      "license": "MIT",
       "dependencies": {
-        "long": "^4.0.0",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-utils": "2.63.2"
+        "long": "5.3.2",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node_modules/node-opcua-debug": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-debug/-/node-opcua-debug-2.63.2.tgz",
-      "integrity": "sha512-BnFJUDfRyMDMKT8GxKB73DGXBxqWxp2UP4Ds7YhEW0RMdouFmB7N1fmKcjR+VqKX+jFVclGQDCWRNdkBGDeS3g==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-debug/-/node-opcua-debug-2.175.1.tgz",
+      "integrity": "sha512-ppDqzEz03rldixADuypjEa/UXUJXKQoYkjigavFXtruE8IcJ+afIxZR8qOYMdw646+BvbLF4mABog32TIV5OnQ==",
+      "license": "MIT",
       "dependencies": {
-        "hexy": "0.3.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-buffer-utils": "2.63.2"
+        "chalk": "4.1.2",
+        "hexy": "0.4.0",
+        "node-opcua-assert": "2.175.1"
       }
     },
     "node_modules/node-opcua-enum": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-enum/-/node-opcua-enum-2.63.2.tgz",
-      "integrity": "sha512-6pDlxO0OUnG/rtmbEAbsOwIhdEPYDi84N2XeNlqqQouWuWnViNwo5wtoD6+ZzzFpksawDf2RyTdTGwWXCO0JWw==",
-      "dependencies": {
-        "node-opcua-assert": "2.63.0"
-      }
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-enum/-/node-opcua-enum-2.175.1.tgz",
+      "integrity": "sha512-IitPGibF9o8MClF1fDR7euxwl7dqVxqwjn8Rwv/CxLSpnlVKx9VUIqucuuIgvfEjb4NtwZ5r/Gb8noWUd3sBXQ==",
+      "license": "MIT"
     },
     "node_modules/node-opcua-extension-object": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-extension-object/-/node-opcua-extension-object-2.63.2.tgz",
-      "integrity": "sha512-yzZBwg0m3oHWFpLGihyyseuNrXCS9Grw/QlbEmD5nBzodgHFUoOehmIuTEcpYLU/oI04aN2e4WWL7GaH9u/OXg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-extension-object/-/node-opcua-extension-object-2.175.1.tgz",
+      "integrity": "sha512-wtGGwBgwONfAvsLXRcrA3VuMGxLv7o3qQGvEA20CZMCigny+Q4N/aPOhKjTrX+zcbrAbmV0oK/EMABSfHd+Xjw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2"
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1"
       }
     },
     "node_modules/node-opcua-factory": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-factory/-/node-opcua-factory-2.63.2.tgz",
-      "integrity": "sha512-0x3xOMSRqY8JjZpfQXLRX+gtaLlhXPq8D8tE2BRO1kgbrQEIS9hvk8dapwVzJ8ngqFn8nxmlnCzyFMdvCwc5IA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-factory/-/node-opcua-factory-2.175.1.tgz",
+      "integrity": "sha512-IZ1tm4PhFyCKNdE69IQ+2Fab5QP1RR5N6eUjmLYuzRkvSUg3o8fBvU7XYydGiaDVYGfDZg6og/eW8YVdePk/Jw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-guid": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2"
-      }
-    },
-    "node_modules/node-opcua-generator": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-generator/-/node-opcua-generator-2.63.2.tgz",
-      "integrity": "sha512-w6BYAxFeDDOOFyF1I+3v9lYH5tnCnBiXZnTq4j1Ts/c9ZDnfreBLaH5QkWERqZA15XRV+5hinACt9FQr24+tBQ==",
-      "dependencies": {
-        "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-guid": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "node-opcua-xml2json": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-guid": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node_modules/node-opcua-guid": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-guid/-/node-opcua-guid-2.63.0.tgz",
-      "integrity": "sha512-ip/AFOjYtjRhowoF0zxu7TJKBgOlRKsuY77FCurMHKvPdqWNuvVzaYRzEZuvs+whKOgvVv95bx4SMJyjknyIYw==",
-      "dependencies": {
-        "node-opcua-assert": "2.63.0"
-      }
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-guid/-/node-opcua-guid-2.175.1.tgz",
+      "integrity": "sha512-NFaMaqd4IflvzImukSloM3Sf5tohIdh+m2OvEfkWA54pzZOebayXwgYHK3IkY16Ey2YWSSmSx7SfLWmjVbUYxw==",
+      "license": "MIT"
     },
     "node_modules/node-opcua-hostname": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-hostname/-/node-opcua-hostname-2.63.0.tgz",
-      "integrity": "sha512-mT1CbSiEBci0JZZEgEYwpUUPp06rVYNJWrvXMKiSW1oVaVdqlpnlLUOBl4koc1e5zfikTtfhCl1H1ZnI+rRrkA==",
-      "dependencies": {
-        "node-opcua-assert": "2.63.0"
-      }
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-hostname/-/node-opcua-hostname-2.175.1.tgz",
+      "integrity": "sha512-boaF8hm56sQjUqf0jkYBmnkc4VjvFwZTKffs5hVLiT+MyW8NXQkIkjlLm/kjNIr4YWnHrVYMb7UI8slJ54xVZA==",
+      "license": "MIT"
     },
     "node_modules/node-opcua-nodeid": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-nodeid/-/node-opcua-nodeid-2.63.2.tgz",
-      "integrity": "sha512-7TdwfnmVaagmcp0dNsXibe22iKfxTWGX8vcQ+3prx4WY5thfj+gAJtbzuost16SHuH3Dh/vqlP6HXsSYbRoTjg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-nodeid/-/node-opcua-nodeid-2.175.1.tgz",
+      "integrity": "sha512-aHRMKI2ruyQCh31THy8gL5ukul+uA3fZKsKt7Fmah174JhxNrjDcKL73K/YTn5sMxhrAsS6vsbxtWN57zVgCdA==",
+      "license": "MIT",
       "dependencies": {
-        "@types/lodash": "4.14.178",
-        "chalk": "4.1.2",
-        "lodash": "4.17.21",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-guid": "2.63.0"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-guid": "2.175.1"
       }
     },
     "node_modules/node-opcua-nodeset-ua": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-nodeset-ua/-/node-opcua-nodeset-ua-2.63.2.tgz",
-      "integrity": "sha512-6BkXJu8F0c2UaW/+l6ynYJW4h5waM3bV/8H1f9UNanX7AawryepAd+SJfssMV9EvO+1Gb8UucjluWpz7runYtQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-nodeset-ua/-/node-opcua-nodeset-ua-2.175.1.tgz",
+      "integrity": "sha512-pgYIgg4MS6SAgCXHOr4hG7u4zE+BdNlV0IJXpXB7HJeEtDymnO/ie3hoWdh6gvWm+mYnZZKHURgBgzvlQdUASQ==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-address-space-base": "2.63.2",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-data-access": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-address-space-base": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-data-access": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-nodesets": {
-      "version": "2.63.0",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-nodesets/-/node-opcua-nodesets-2.175.1.tgz",
+      "integrity": "sha512-4u/lrw8BOHhInw9aWmiQW657NUgbHOLmifnBY+QU4kwjZ92QshrmSLXTVLDj3V7s0krw+Rzyrqyrkhn7I0+UEg==",
       "license": "MIT"
     },
     "node_modules/node-opcua-numeric-range": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-numeric-range/-/node-opcua-numeric-range-2.63.2.tgz",
-      "integrity": "sha512-o/qFWlIgnsHjC/yvQf/JVWbBDYLOyWYGQl7yH/wSzQqgUOsm+L6gEUJv5K9XNx07SGcCV/KBQOfyuz/kYTsp/w==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-numeric-range/-/node-opcua-numeric-range-2.175.1.tgz",
+      "integrity": "sha512-zYToOjPBn7BalZzOcLPnQINWSPBJTqYdp0W9GtRby6zx2hHa95dgQ5YsD6IIxLPVCQY/k92axsDOIednI7IWZA==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-status-code": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-status-code": "2.175.1"
       }
     },
     "node_modules/node-opcua-object-registry": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-object-registry/-/node-opcua-object-registry-2.63.2.tgz",
-      "integrity": "sha512-AL9qvFxk+5r8qSotBqLTJGI8xo43lX1MR+bEdF2soMoghvn9hz3pHaSEeXCXb7YAGLghBMCgbx5VZGZF7i7piw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-object-registry/-/node-opcua-object-registry-2.175.1.tgz",
+      "integrity": "sha512-bG1WqH/dXaaUw+tu/L+s6WgroPCqP7QAkfYppVOe9FcV074G5BXr1Ddf8PlLqxvdnouDrf7+0JBjc+zjiGn8Ew==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-debug": "2.63.2"
+        "node-opcua-debug": "2.175.1"
       }
     },
     "node_modules/node-opcua-packet-analyzer": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-packet-analyzer/-/node-opcua-packet-analyzer-2.63.2.tgz",
-      "integrity": "sha512-+zgPnby9XEnHCAJSwIDeBwLmD8+mwduQBkSIP/PHVJ32JuOmOnkq+iXBZYrjRQ4oG9Wmdqtu/j7h7MHa5Esjeg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-packet-analyzer/-/node-opcua-packet-analyzer-2.175.1.tgz",
+      "integrity": "sha512-0fsAzQNm95aVxI77KMTn5wly5522gUvDf2P7IMZE01TIz4p1QFsWDPtuB+ajHILgLyLcW+E8XguJ1NJp4fZjeA==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node_modules/node-opcua-packet-assembler": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-packet-assembler/-/node-opcua-packet-assembler-2.63.0.tgz",
-      "integrity": "sha512-v+aFpIhJZIompyqXiQNrCg4yjYq+oC7LsBQdxyIWZhv3t/hzC9NJ9MI+sAd4YmOaRHkx9ORKRjhsUjvE4KRnVg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-packet-assembler/-/node-opcua-packet-assembler-2.175.1.tgz",
+      "integrity": "sha512-pZzh83GWZukdYEIoYiOX7TgcnU8Ldpi8rjjLXkak8mc7cDzeF6TWdffH5kCStRBX5CzvcpdpUB+O/+eo62MlwA==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-debug": "2.175.1"
       }
     },
     "node_modules/node-opcua-pki": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-pki/-/node-opcua-pki-2.13.0.tgz",
-      "integrity": "sha512-qi0x36RaGG246Le0XrKbq51IU12d6oBeEqABwVV9ivoWvEa8tvedurc2eblpIZvjErFxKb9g4L3gQa0zOBIuyA==",
+      "version": "6.18.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-pki/-/node-opcua-pki-6.18.0.tgz",
+      "integrity": "sha512-y3BKrgo9LYDUkP1pcpmAzZDXJJXr/h464XV6PhVXjibrQOAXPW3oPk75WzVZNl6OLUtEp4WXn3RxwQ2RtJM9yQ==",
+      "license": "MIT",
       "dependencies": {
-        "@ster5/global-mutex": "^1.2.0",
+        "@ster5/global-mutex": "^3.3.0",
         "byline": "^5.0.0",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.2",
-        "cli-table": "^0.3.9",
-        "node-opcua-crypto": "^1.8.0",
-        "progress": "^2.0.3",
-        "thenify": "^3.3.1",
-        "update-notifier": "5.1.0",
-        "wget-improved": "^3.2.1",
-        "yargs": "17.2.1",
-        "yauzl": "^2.10.0"
+        "chalk": "4.1.2",
+        "chokidar": "4.0.3",
+        "command-line-args": "^6.0.2",
+        "command-line-usage": "^7.0.4",
+        "node-opcua-crypto": "5.3.6",
+        "yauzl": "^3.3.0"
       },
       "bin": {
-        "pki": "bin/crypto_create_CA.js"
-      }
-    },
-    "node_modules/node-opcua-pki/node_modules/node-opcua-crypto": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-crypto/-/node-opcua-crypto-1.8.0.tgz",
-      "integrity": "sha512-rFFsDKAJg1rxoSCXZ2JOTybyC+Aw/jLm8ksiiROX69ZZoFw9rgoA+Ohiue8fK7Dt0+FjTMBZf0gqOuFXmIbiDg==",
-      "dependencies": {
-        "better-assert": "^1.0.2",
-        "chalk": "^4.1.1",
-        "hexy": "^0.3.1",
-        "jsrsasign": "^10.2.0",
-        "sshpk": "^1.16.1"
+        "node-opcua-pki": "dist/bin/pki.mjs",
+        "pki": "dist/bin/pki.mjs"
       }
     },
     "node_modules/node-opcua-pseudo-session": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-pseudo-session/-/node-opcua-pseudo-session-2.63.2.tgz",
-      "integrity": "sha512-8An89bWF2f4CIIU4inu/PLMGhK2iAepwLPvc29iV9sYfbYbpeaaJCfUSvpWOtruzhc0Pew2hr5evl+C6i7Exfw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-pseudo-session/-/node-opcua-pseudo-session-2.175.1.tgz",
+      "integrity": "sha512-w2tyiqmZDQVo4/4YPjGjAJ688AxzOaQE0s5AHDnKFFYWmC1nq4LdhrYyAg1Vf1L+p8lNyB3KHn9UN1OKxCCcmw==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-schemas": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-schemas/-/node-opcua-schemas-2.63.2.tgz",
-      "integrity": "sha512-SL/M62RCylprfbsa4mFfXSA7fcRn1BkM77eL+ASrZ0F/4FiM7Yv2ySrBK7WgmzVDZnuyjkVijLjiAJVBVUXeaA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-schemas/-/node-opcua-schemas-2.175.1.tgz",
+      "integrity": "sha512-Kcg2IcSjwdoRK0m5CRyX/kgW8hr40LQY+VhjygbH5wePMyTRF5H1iGmpPnGY86GYXK4Hdib6u0InEwSSpdLdLg==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "node-opcua-xml2json": "2.63.2",
-        "thenify": "^3.3.1"
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-variant": "2.175.1",
+        "node-opcua-xml2json": "2.175.1"
       }
     },
     "node_modules/node-opcua-secure-channel": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-secure-channel/-/node-opcua-secure-channel-2.63.2.tgz",
-      "integrity": "sha512-JXMFPvKnsFLrL9SsSb9rxQ4mimwY3X49hn0bFkUoqrzWhIiZvVlE6Bs0NW8hXms7eUnS2qVUlFdUv2zJywTylQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-secure-channel/-/node-opcua-secure-channel-2.175.1.tgz",
+      "integrity": "sha512-xJeZvj6RX1wXWLU1NTi2wnHHvIayUP3chPZxHYzTVX3Aw+wWbGu8ghXNKEr7htoLk/p9Mr7gPIVWnCMxxVeqxw==",
+      "license": "MIT",
       "dependencies": {
-        "@types/underscore": "1.11.4",
-        "async": "^3.2.3",
         "backoff": "^2.5.0",
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-certificate-manager": "2.63.2",
-        "node-opcua-chunkmanager": "2.63.2",
-        "node-opcua-common": "2.63.2",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-packet-analyzer": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-transport": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-chunkmanager": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-packet-analyzer": "2.175.1",
+        "node-opcua-service-endpoints": "2.175.1",
+        "node-opcua-service-secure-channel": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-transport": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node_modules/node-opcua-server": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-server/-/node-opcua-server-2.63.2.tgz",
-      "integrity": "sha512-mN4375Qml5RlH2MFh2oTDJg5JbdFV1KsSuK85gQMXg5h2B8GA5oXJPd2j6IWoBHIjC85Z8hHKOUPcyTdPn1Kvw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-server/-/node-opcua-server-2.175.1.tgz",
+      "integrity": "sha512-GhXroHlCE0N4xXoV1sM5IJKl4mO3HnOfSGC6AxNucW5zJZERX5r5hod2ZWE1WlsJ/m+INT2dlepKZfGyUzu42Q==",
+      "license": "MIT",
       "dependencies": {
-        "@ster5/global-mutex": "^1.2.0",
-        "@types/underscore": "^1.11.4",
-        "async": "^3.2.3",
-        "bonjour": "^3.5.0",
+        "@ster5/global-mutex": "^3.3.0",
+        "chalk": "4.1.2",
         "dequeue": "^1.0.5",
-        "lodash": "4.17.21",
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-certificate-manager": "2.63.2",
-        "node-opcua-client": "2.63.2",
-        "node-opcua-client-dynamic-extension-object": "2.63.2",
-        "node-opcua-common": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-hostname": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-nodesets": "2.63.0",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pki": "^2.13.0",
-        "node-opcua-secure-channel": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-discovery": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-service-node-management": "2.63.2",
-        "node-opcua-service-query": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-register-node": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-service-session": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "lodash.partition": "^4.6.0",
+        "lodash.sortby": "^4.7.0",
+        "node-opcua-address-space": "2.175.1",
+        "node-opcua-address-space-base": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-certificate-manager": "2.175.1",
+        "node-opcua-client": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-hostname": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-nodesets": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-pki": "6.18.0",
+        "node-opcua-secure-channel": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-discovery": "2.175.1",
+        "node-opcua-service-endpoints": "2.175.1",
+        "node-opcua-service-filter": "2.175.1",
+        "node-opcua-service-history": "2.175.1",
+        "node-opcua-service-node-management": "2.175.1",
+        "node-opcua-service-query": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-register-node": "2.175.1",
+        "node-opcua-service-secure-channel": "2.175.1",
+        "node-opcua-service-session": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-transport": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1",
+        "thenify-ex": "4.4.0"
       }
     },
     "node_modules/node-opcua-server-discovery": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-server-discovery/-/node-opcua-server-discovery-2.63.2.tgz",
-      "integrity": "sha512-Hizmzl5f6clR/D/rmV0aAQWv9SeAL3lxLqv35vuRBQwy+BPZddsIORHq3AgjssOQfT8KsLWSYR5jWra4BbOF6A==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-server-discovery/-/node-opcua-server-discovery-2.175.1.tgz",
+      "integrity": "sha512-IhGRA+zdw0TeiKIziO7CLYhKjtD8cTAsa7S74/hG4Ut8cTqfoAoAR+e3Ix9RKRynXemdemMG8f5Iajya0OWQgg==",
+      "license": "MIT",
       "dependencies": {
-        "@types/bonjour": "^3.5.10",
-        "bonjour": "^3.5.0",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-certificate-manager": "2.63.2",
-        "node-opcua-common": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-hostname": "2.63.0",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pki": "^2.13.0",
-        "node-opcua-secure-channel": "2.63.2",
-        "node-opcua-server": "2.63.2",
-        "node-opcua-service-discovery": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-status-code": "2.63.2"
+        "chalk": "4.1.2",
+        "env-paths": "2.2.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-certificate-manager": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-secure-channel": "2.175.1",
+        "node-opcua-server": "2.175.1",
+        "node-opcua-service-discovery": "2.175.1",
+        "node-opcua-service-endpoints": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "sterfive-bonjour-service": "1.1.4",
+        "thenify-ex": "4.4.0"
       }
     },
     "node_modules/node-opcua-service-browse": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-browse/-/node-opcua-service-browse-2.63.2.tgz",
-      "integrity": "sha512-bKGO0B9FNFZ2k+7QsLairLnsb9LEcgag8BFCkTIDGb4GY8ca4QCWpNj4kKuPUAzw2xz+ZZBrpwmd0Bij0VtBiQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-browse/-/node-opcua-service-browse-2.175.1.tgz",
+      "integrity": "sha512-HnTq2DHTYs9YBvQfjns2Ux5tXY/H0pIOwzpuK6NvL55ZoNyd5KReub2MM5s9DQSGUW36ggBRTCLr5YMjzzH4yA==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-call": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-call/-/node-opcua-service-call-2.63.2.tgz",
-      "integrity": "sha512-Tsjyu+k0G0a7tF/nRkFx+k+3ggKmBLF8YGbmSbVkrHdE0y7BSu+7YR9A968IvDJ18n96TfbRgDGZZdGS9dJfKw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-call/-/node-opcua-service-call-2.175.1.tgz",
+      "integrity": "sha512-URaWpLorjBj4mOHWnXPsnTRDJJtyl6u271iDAEUyNHA2RYlwlRG/JnQ+t0lQF11ru1W0MnSFrJ8HDPeV0NGuEw==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-discovery": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-discovery/-/node-opcua-service-discovery-2.63.2.tgz",
-      "integrity": "sha512-/xmObzr+bMsY4CBP/rrBtC2xLst98IAvZDB98IWebqBgqZdheA5UZ39kryUzbaZHUx4eGEFoReC6aRYAOOH20A==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-discovery/-/node-opcua-service-discovery-2.175.1.tgz",
+      "integrity": "sha512-Afx3hvTTz5vjtuOLElcF8VzdU50xIJC0c/LBokqQ8W2iJ+gS1uutkFr/2dEIoNmV+U3inqWmgxOmn7X4BTTb3A==",
+      "license": "MIT",
       "dependencies": {
-        "@types/bonjour": "^3.5.10",
-        "bonjour": "^3.5.0",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "sterfive-bonjour-service": "1.1.4"
       }
     },
     "node_modules/node-opcua-service-endpoints": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-endpoints/-/node-opcua-service-endpoints-2.63.2.tgz",
-      "integrity": "sha512-fmF5JRmVKSHQwMLxEIuA+DyIMeZk9sJRgGxh+OtEYXNwPmgteoRhAKO5Oun33TQGvtNpgoAkTHXkZztUEUwyNg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-endpoints/-/node-opcua-service-endpoints-2.175.1.tgz",
+      "integrity": "sha512-j7SHDmq4e5cUY20nCy9tDa8U+rtARh9Z5FPXxcwLbdENu52h04ml8SaJgaz1Idj3/iOHB6o5rTL2BZaob3oOhg==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-filter": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-filter/-/node-opcua-service-filter-2.63.2.tgz",
-      "integrity": "sha512-oYmeOzRKbVj1r8/NnxnW+iYbjLjnqvOpKVp1hlqBfbF4tm1/NI/ngSrtq07Wn1NXdV/V0OzXiCYjAsyjqmC5cA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-filter/-/node-opcua-service-filter-2.175.1.tgz",
+      "integrity": "sha512-Xw6CKS7NqbnDPG7Y9NjRV/F9b+lmMNLJ6mPyr1WZDkkYuyM+NsU0xg0GjnCG9Ro99OBgzu6IZUIRImhSr4gjYw==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-address-space-base": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-history": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-history/-/node-opcua-service-history-2.63.2.tgz",
-      "integrity": "sha512-EIfHKq94A1p+wGKLbD8u0MDgYrCw2Qy+xcooE0MAuZ3viNuEItRq9uu/a9GpVlwDfueEWbEQcU1C4EbFZ6PjSA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-history/-/node-opcua-service-history-2.175.1.tgz",
+      "integrity": "sha512-YUfp9Z/W4/PqKUrMOIikgXYyugax8YH3NdsHQbCd+BbFlzujlaM63Qmmd7iFDW0SzSRduhMWymOi5l69mZBwGA==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-node-management": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-node-management/-/node-opcua-service-node-management-2.63.2.tgz",
-      "integrity": "sha512-3dP67VJOqdu+phHgDkI6t/3UFWHJwisv2acxAiMU9Ue+hTAYgGzibANIl+Fl1jT+pxsInDROMvXuEnC7HphkNA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-node-management/-/node-opcua-service-node-management-2.175.1.tgz",
+      "integrity": "sha512-y+wJlNpkbcsie4cRG7YPELUD1VIFKr/oVNPGHMM2fEnsy7inSSNz0dH9BCEu/E3MxFMq+iKWen4GUN0zSQCmJA==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-query": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-query/-/node-opcua-service-query-2.63.2.tgz",
-      "integrity": "sha512-MBVAPhL2l2THiUcLNI2DYw6MC7JD/2+yhLEesnd5tCu33cHd2LGr9wigR2jUtjYrVNPAN7VG+K7q5LbIYHI16w==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-query/-/node-opcua-service-query-2.175.1.tgz",
+      "integrity": "sha512-Gdb1ZYwqlZfn5ssud+L9QQMMbgeBBMZOSAyKIAw4yKHem+cNejQ4Q9C5lEFve6DgSl0BVYZf2tilH5/VIXujBQ==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-read": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-read/-/node-opcua-service-read-2.63.2.tgz",
-      "integrity": "sha512-a+mXiptPfQQ7p55UU7qAgZU1BPAEJqxv/UPk77wQCdczwcD01K6R9OCILW2Aes9eX0S6fn1K9IR113296DWDbA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-read/-/node-opcua-service-read-2.175.1.tgz",
+      "integrity": "sha512-JzG3swpUETA4q5SdLXK7zIP7UJQnFbIz9mSXV+WkYuSNk9MvvdgIya2/VSsGZRA1SBWa3zRmLVlW+4t2/rwaXA==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-service-secure-channel": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-register-node": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-register-node/-/node-opcua-service-register-node-2.63.2.tgz",
-      "integrity": "sha512-nsH0Cfpc6kHLd4W2F/F9wmPjV5aNt/9H/vNrmhLf/1+koc6uYpLNaLZYHuGSCW78ah9ICfWyBxOSKWZWtYOLDQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-register-node/-/node-opcua-service-register-node-2.175.1.tgz",
+      "integrity": "sha512-tMW60af3FeFkW9yzWTfBMsJSBBT06E6132PcRgvXq5pKYhCi2z0ZjJz2Tref/wRlSvIFn+i1+JsBT+rwAyfK5Q==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-secure-channel": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-secure-channel/-/node-opcua-service-secure-channel-2.63.2.tgz",
-      "integrity": "sha512-te9Sn3jvmKRUVR9cfuoBw+o0w5f4z68GWMu2wcEqZbGP1+QedUUFRFMh4OgdECdiD4mXatxXPASuIoAVITYOzQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-secure-channel/-/node-opcua-service-secure-channel-2.175.1.tgz",
+      "integrity": "sha512-anECfPKt6l94xylD+GgXOYe3pF5bJ/+FBcpiBpN7tuYP60OASkJWCB5Kd3Le2T3wPmaWWBHsnmImo7RGWCMMnA==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-session": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-session/-/node-opcua-service-session-2.63.2.tgz",
-      "integrity": "sha512-kwbSWm5aDTAkiZ3IjzZtUqf5qL8j02E+Gdb1dUiJplgEs6TwW7NiEiK5btKABe+fPfY3vcqWeX6m8mOEia4IhA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-session/-/node-opcua-service-session-2.175.1.tgz",
+      "integrity": "sha512-9qM1FSWG1/6KuExWI/NyOej8dLo/gwf6+9JsyOl2uFdipNaeVJVhwCHkl6EHhii0lqG1D3QCtHV/VOGkiRweDQ==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-subscription": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-subscription/-/node-opcua-service-subscription-2.63.2.tgz",
-      "integrity": "sha512-0EaLSaJGRG4KN/pcQoqFkPfGpEGxxTy+id7LybFWoMYoWx2599iCaJePlNZ72SbuJwhngc5mEOckY28edyXPjA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-subscription/-/node-opcua-service-subscription-2.175.1.tgz",
+      "integrity": "sha512-fOKq90qjNiAce9j4h0jGbcwguYlVoqbjPJzNy8d2XCmOCnmlfY3SPHDjO2iSMLJkFpWzgM9Gj/hEdUnSzW1/TA==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-translate-browse-path": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-translate-browse-path/-/node-opcua-service-translate-browse-path-2.63.2.tgz",
-      "integrity": "sha512-lTOo7Ywg8flHtVWpn+TvLWIIwzYg+zy+FbLxjGfIntyzpv/8YwnUrOx2CRK8DTwG+u+pUngAPgTKSm+21IP1EA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-translate-browse-path/-/node-opcua-service-translate-browse-path-2.175.1.tgz",
+      "integrity": "sha512-3TjSoNEusC68k4G4zjpQftYalMjkIxCbeI74iSxeADvzcSXD5OF+0y8NmEcXHJubmcQhO7gYbvxf0PznvpvsbA==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-service-write": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-write/-/node-opcua-service-write-2.63.2.tgz",
-      "integrity": "sha512-Gib+m5bNOLNQiCLjY29Gw2qY7SOH2cxUnDoXmcvzCQG74vh/WPAOBZvk6GbqHB1cmdISySZH9Dcbwc3V/DS+/g==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-write/-/node-opcua-service-write-2.175.1.tgz",
+      "integrity": "sha512-M7IS2wGPVOJbjG8MadfVBtang5cOESiOlqjMItqA+bqjISIYj2jLLl4ufIstyBKuEvy1uoV4pgbPaoDLdwrTlA==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-types": "2.175.1"
       }
     },
     "node_modules/node-opcua-status-code": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-status-code/-/node-opcua-status-code-2.63.2.tgz",
-      "integrity": "sha512-T3nQHBKRTznwKFx7UPkxs/JccIKVf9u21im9IUt+OOpJ6ZhRFGYBPPs+/xSL9jrWrkE0Do9w1c5vrxNzILV0Iw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-status-code/-/node-opcua-status-code-2.175.1.tgz",
+      "integrity": "sha512-2+kDiVBIz/8Idzf3MohENlGPuenjoQGQsEKudqB1EMFIhVsUvGHTR6gumn3M7PucOb+zmxUGFBt8aDfioDWqLQ==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1"
       }
     },
     "node_modules/node-opcua-transport": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-transport/-/node-opcua-transport-2.63.2.tgz",
-      "integrity": "sha512-xZsjTbt8I8QsXTM8LqDEcKYy2hNiYxg+50MK6lVYysnSJr/r5wJWokh3R6Kys9vVfuVIeJ/HSzTTF/Lxlt25rQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-transport/-/node-opcua-transport-2.175.1.tgz",
+      "integrity": "sha512-hy3BvjYmQ1WSoTzRPAGvo0wOzPTadgS1QBmSKDaj7EPgptyhcRUVYlSQ0PhtLxUfIN+yvyCNi+X+sd4P//ZN9w==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-chunkmanager": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-packet-assembler": "2.63.0",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-buffer-utils": "2.175.1",
+        "node-opcua-chunkmanager": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-packet-assembler": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node_modules/node-opcua-types": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-types/-/node-opcua-types-2.63.2.tgz",
-      "integrity": "sha512-/cqFFftZw18bYRZkp7DFKeB+gQeuU6hWjdKyf5ssxiVMJOqhug80o5qeq6b3kFssdVw4L9wQ5DIyK3T7lwKQlw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-types/-/node-opcua-types-2.175.1.tgz",
+      "integrity": "sha512-ONdJ5LGqKTHaRWGsqHgzpcA3lK/YaHOKf4N9x+lheERZAuYUtAZ0GGqRH4fk+OlZV9oLEtSTx2MsR7rp6FaSYw==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-generator": "2.63.2",
-        "node-opcua-guid": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-packet-analyzer": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-utils": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-utils/-/node-opcua-utils-2.63.2.tgz",
-      "integrity": "sha512-BAAfnxkYBFkxIyVr34paG5gyLYQJtKYyOj3RqOMwJEY2PMgITMxAJWGZh+NfsFPniczH+wgkooHw6qVOqEygxA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-utils/-/node-opcua-utils-2.175.1.tgz",
+      "integrity": "sha512-10NAnKsRN2hrMg4dy4hFunx4eUfP1YnW84SFY7gD39piHPENdwDL83rCaYfnD02TrZOF1noWV6gLbMw2xKOJzg==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0"
+        "node-opcua-assert": "2.175.1"
       }
     },
     "node_modules/node-opcua-variant": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-variant/-/node-opcua-variant-2.63.2.tgz",
-      "integrity": "sha512-gd1cSz4MO1yYnMpx7qKavUA9h8y8Io4AQCCeVqyKcM7kP0JY08LnuGW37gnkhaVWj3CM1Zf4qswTGNxZs6vMdQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-variant/-/node-opcua-variant-2.175.1.tgz",
+      "integrity": "sha512-UgIA8n+BptK7GzispdKrxumKE/qSV3IgpoxkzVgx8qrXCfYH6No2/1HR0gaO5oAj679hsrpC1WFn8bijvNRmdg==",
+      "license": "MIT",
       "dependencies": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node_modules/node-opcua-vendor-diagnostic": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-vendor-diagnostic/-/node-opcua-vendor-diagnostic-2.63.2.tgz",
-      "integrity": "sha512-O7Ziq4nmt7Fjy+gUXSCtcvJQkVmiFTGf+05K0EQZ0eEl1M6SBMwQ+BrpghRmxI/6Hi4Il3i4JLyDWVPgOfepmg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-vendor-diagnostic/-/node-opcua-vendor-diagnostic-2.175.1.tgz",
+      "integrity": "sha512-FAPYgkt/3REq5P+YBZerY3zcIdtB4YWClmfzGqNTo6Qbteqtje11jhSeIATtL0tiPoM+5raO87I+AZ/isktqiw==",
+      "license": "MIT",
       "dependencies": {
         "humanize": "0.0.9",
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-server": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-address-space": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-server": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node_modules/node-opcua-xml2json": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-xml2json/-/node-opcua-xml2json-2.63.2.tgz",
-      "integrity": "sha512-oY1LFaYBswctkkxPvi0cfPvyY70qMtLgK/WMjVoRSNQ1r1cN/4oU9xl7kSKcRdHskOLZSm88EkeyekcHbQQBBQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-xml2json/-/node-opcua-xml2json-2.175.1.tgz",
+      "integrity": "sha512-EBYg27WlNS2LqjVE2ojOngFDKnZ2/mXpuzBH3GJA3y9noI3M3pbfsJpsNyJ773//0vSO0gYZcqCSG1ApSPlXZw==",
+      "license": "MIT",
       "dependencies": {
-        "bomstrip": "^0.1.4",
-        "ltx": "^3.0.0",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-utils": "2.63.2",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-utils": "2.175.1",
         "xml-writer": "^1.7.0"
       }
     },
@@ -4165,20 +3680,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-url": {
-      "version": "4.5.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm": {
@@ -6137,37 +5638,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -6182,14 +5652,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-cancelable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/p-each-series": {
@@ -6284,28 +5746,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/package-json": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
-      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
-      "dependencies": {
-        "got": "^9.6.0",
-        "registry-auth-token": "^4.0.0",
-        "registry-url": "^5.0.0",
-        "semver": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/package-json/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/parent-module": {
@@ -6411,8 +5851,9 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6425,6 +5866,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -6551,18 +5993,10 @@
     },
     "node_modules/precond": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/prepend-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/pretty-ms": {
@@ -6587,14 +6021,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -6602,30 +6028,29 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
       "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "tslib": "^2.8.1"
       }
     },
-    "node_modules/pupa": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
-      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
-      "dependencies": {
-        "escape-goat": "^2.0.0"
-      },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -6639,7 +6064,8 @@
     "node_modules/rc/node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "node_modules/read-package-up": {
       "version": "12.0.0",
@@ -6716,57 +6142,29 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
+      "version": "4.1.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
+        "node": ">= 14.18.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/registry-auth-token": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
-      "dependencies": {
-        "rc": "^1.2.8"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/registry-url": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
-      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
-      "dependencies": {
-        "rc": "^1.2.8"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6780,37 +6178,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/responselike": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-      "dependencies": {
-        "lowercase-keys": "^1.0.0"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/semantic-release": {
       "version": "25.0.3",
@@ -7073,34 +6445,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/semver-diff": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
-      "dependencies": {
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semver-diff/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/semver-regex": {
@@ -7115,11 +6468,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/set-prototype-of": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-prototype-of/-/set-prototype-of-1.0.0.tgz",
-      "integrity": "sha1-gCIdbaDsaFEd3HQ5CXV60UT8Hf0="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7143,11 +6491,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
     },
     "node_modules/signale": {
       "version": "1.4.0",
@@ -7303,9 +6646,10 @@
       "license": "CC0-1.0"
     },
     "node_modules/sshpk": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "version": "1.18.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -7324,6 +6668,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sterfive-bonjour-service": {
+      "version": "1.1.4",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/sterfive-bonjour-service/-/sterfive-bonjour-service-1.1.4.tgz",
+      "integrity": "sha512-QqDpnBb3KLD6ytdY2KSxsynw1jJAvzfOloQt83GQNXO6CGf84ZY+37tpOEZo1FzgUkFiVsL7pYyg71olDppI/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/multicast-dns": "^7.2.1",
+        "array-flatten": "^2.1.2",
+        "dns-equal": "^1.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.4"
       }
     },
     "node_modules/stream-combiner2": {
@@ -7366,6 +6723,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7379,6 +6737,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -7412,6 +6771,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7460,6 +6820,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/tagged-tag": {
@@ -7579,6 +6952,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -7596,10 +6970,17 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/thenify-ex": {
+      "version": "4.4.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/thenify-ex/-/thenify-ex-4.4.0.tgz",
+      "integrity": "sha512-YHA/2DlY1vWpqGLCc7BzdT9aTrqyHCbsX5J3zbW68LLeD4RPwd+2tMEWshMP+27ikuTnaeKbFDmjqc7fKWmDew==",
+      "license": "MIT"
+    },
     "node_modules/thunky": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "license": "MIT"
     },
     "node_modules/time-span": {
       "version": "5.1.0",
@@ -7665,18 +7046,11 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/to-readable-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7691,18 +7065,44 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
     },
     "node_modules/type-fest": {
       "version": "5.5.0",
@@ -7720,25 +7120,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.9.3",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/uglify-js": {
@@ -7755,11 +7157,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
-    },
     "node_modules/undici": {
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
@@ -7769,6 +7166,12 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",
@@ -7793,17 +7196,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "dependencies": {
-        "crypto-random-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
@@ -7821,33 +7213,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/update-notifier": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
-      "integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
-      "dependencies": {
-        "boxen": "^5.0.0",
-        "chalk": "^4.1.0",
-        "configstore": "^5.0.1",
-        "has-yarn": "^2.1.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.4.0",
-        "is-npm": "^5.0.0",
-        "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.1.0",
-        "pupa": "^2.1.1",
-        "semver": "^7.3.4",
-        "semver-diff": "^3.1.1",
-        "xdg-basedir": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
-      }
-    },
     "node_modules/url-join": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
@@ -7856,17 +7221,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/url-parse-lax": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-      "dependencies": {
-        "prepend-http": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/util-deprecate": {
@@ -7893,19 +7247,17 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/wget-improved": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/wget-improved/-/wget-improved-3.2.1.tgz",
-      "integrity": "sha512-bZmRufYav/OFRdS8LerCbzP3b/L8tjRwqap6NhqcvEAfZrBMFwqjtFzbVk2gutEWdG78WKJgIn9yveI+ENQSlA==",
+    "node_modules/webcrypto-core": {
+      "version": "1.9.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+      "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
+      "license": "MIT",
       "dependencies": {
-        "minimist": "1.2.5",
-        "tunnel": "0.0.6"
-      },
-      "bin": {
-        "nwget": "bin/nwget"
-      },
-      "engines": {
-        "node": ">= 0.6.18"
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/which": {
@@ -7924,17 +7276,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/widest-line": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-      "dependencies": {
-        "string-width": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -7942,10 +7283,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7956,22 +7307,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
       }
     },
     "node_modules/ws": {
@@ -7994,18 +7329,11 @@
         }
       }
     },
-    "node_modules/xdg-basedir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/xml-writer": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/xml-writer/-/xml-writer-1.7.0.tgz",
-      "integrity": "sha1-t28dWRwWomNOvbcDx729D9aBkGU=",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/xml-writer/-/xml-writer-1.7.0.tgz",
+      "integrity": "sha512-elFVMRiV5jb59fbc87zzVa0C01QLBEWP909mRuWqFqrYC5wNTH5QW4AaKMNv7d6zAsuOulkD7wnztZNLQW0Nfg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -8023,42 +7351,30 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
-      "integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "version": "3.4.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yoctocolors": {
@@ -8142,6 +7458,11 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
       "optional": true
+    },
+    "@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
     },
     "@octokit/auth-token": {
       "version": "6.0.0",
@@ -8251,6 +7572,167 @@
       "dev": true,
       "requires": {
         "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "@peculiar/asn1-cms": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-csr": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pfx": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pkcs8": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-pkcs9": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "requires": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/asn1-x509-attr": {
+      "version": "2.8.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "requires": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.7.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+      "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "tslib": "^2.8.1",
+        "webcrypto-core": "^1.9.2"
+      }
+    },
+    "@peculiar/x509": {
+      "version": "2.0.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@peculiar/x509/-/x509-2.0.0.tgz",
+      "integrity": "sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
       }
     },
     "@pnpm/config.env-replace": {
@@ -8474,9 +7956,6 @@
       "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
       "dev": true
     },
-    "@sindresorhus/is": {
-      "version": "0.14.0"
-    },
     "@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -8484,34 +7963,34 @@
       "dev": true
     },
     "@ster5/global-mutex": {
-      "version": "1.2.0"
+      "version": "3.3.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@ster5/global-mutex/-/global-mutex-3.3.0.tgz",
+      "integrity": "sha512-uiGJTiE0ZiQ6z9VMOHVT3RNrErCi3pZh1bGbfb27GAXCAsvCyLz61pLfBYq8uzsf6Y2qdybhoTwHy7UGtK6MYw=="
     },
-    "@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "requires": {
-        "defer-to-connect": "^1.0.1"
-      }
-    },
-    "@types/async": {
-      "version": "3.2.12"
-    },
-    "@types/bonjour": {
-      "version": "3.5.10",
+    "@types/dns-packet": {
+      "version": "5.6.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@types/dns-packet/-/dns-packet-5.6.5.tgz",
+      "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
       "requires": {
         "@types/node": "*"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.178"
-    },
-    "@types/mkdirp": {
-      "version": "1.0.1",
+    "@types/multicast-dns": {
+      "version": "7.2.4",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@types/multicast-dns/-/multicast-dns-7.2.4.tgz",
+      "integrity": "sha512-ib5K4cIDR4Ro5SR3Sx/LROkMDa0BHz0OPaCBL/OSPDsAXEGZ3/KQeS6poBKYVN7BfjXDL9lWNwzyHVgt/wkyCw==",
       "requires": {
+        "@types/dns-packet": "*",
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "17.0.14"
+      "version": "20.19.43",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.4",
@@ -8519,16 +7998,15 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
-    "@types/once": {
-      "version": "1.4.0"
-    },
-    "@types/underscore": {
-      "version": "1.11.4"
+    "@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="
     },
     "@types/ws": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
-      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "version": "8.18.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -8550,14 +8028,6 @@
         "indent-string": "^5.0.0"
       }
     },
-    "ansi-align": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "requires": {
-        "string-width": "^4.1.0"
-      }
-    },
     "ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -8568,7 +8038,8 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -8577,16 +8048,8 @@
       }
     },
     "any-promise": {
-      "version": "1.3.0"
-    },
-    "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      }
+      "version": "1.3.0",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -8598,8 +8061,15 @@
       "version": "1.0.0",
       "dev": true
     },
+    "array-back": {
+      "version": "6.2.3",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw=="
+    },
     "array-flatten": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/array-flatten/-/array-flatten-2.1.2.tgz",
+      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
     },
     "array-ify": {
       "version": "1.0.0",
@@ -8609,30 +8079,39 @@
     },
     "asn1": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
-    "assert-plus": {
-      "version": "1.0.0"
+    "asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "requires": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      }
     },
-    "async": {
-      "version": "3.2.3"
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
     },
     "backoff": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==",
       "requires": {
         "precond": "0.2"
       }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -8643,97 +8122,31 @@
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "dev": true
     },
-    "better-assert": {
-      "version": "1.0.2",
-      "requires": {
-        "callsite": "1.0.0"
-      }
-    },
-    "binary-extensions": {
-      "version": "2.2.0"
-    },
-    "bomstrip": {
-      "version": "0.1.4"
-    },
-    "bonjour": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
-      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
-      "requires": {
-        "array-flatten": "^2.1.0",
-        "deep-equal": "^1.0.1",
-        "dns-equal": "^1.0.0",
-        "dns-txt": "^2.0.2",
-        "multicast-dns": "^6.0.1",
-        "multicast-dns-service-types": "^1.1.0"
-      }
-    },
     "bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true
     },
-    "boxen": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
-      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
-      "requires": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.1.0",
-        "cli-boxes": "^2.2.1",
-        "string-width": "^4.2.2",
-        "type-fest": "^0.20.2",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
-        }
-      }
-    },
     "braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "requires": {
         "fill-range": "^7.1.1"
       }
     },
-    "buffer-crc32": {
-      "version": "0.2.13"
-    },
-    "buffer-indexof": {
-      "version": "1.1.1"
-    },
     "byline": {
-      "version": "5.0.0"
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      }
-    },
-    "callbackify": {
-      "version": "1.1.0"
-    },
-    "callsite": {
-      "version": "1.0.0"
+      "version": "5.0.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q=="
     },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
-    },
-    "camelcase": {
-      "version": "6.3.0"
     },
     "chalk": {
       "version": "4.1.2",
@@ -8744,6 +8157,14 @@
         "supports-color": "^7.1.0"
       }
     },
+    "chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "requires": {
+        "chalk": "^4.1.2"
+      }
+    },
     "char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -8751,22 +8172,12 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "version": "4.0.3",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "requires": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^4.0.1"
       }
-    },
-    "ci-info": {
-      "version": "2.0.0"
     },
     "clean-stack": {
       "version": "5.3.0",
@@ -8784,9 +8195,6 @@
           "dev": true
         }
       }
-    },
-    "cli-boxes": {
-      "version": "2.2.1"
     },
     "cli-highlight": {
       "version": "2.1.11",
@@ -8819,12 +8227,6 @@
         }
       }
     },
-    "cli-table": {
-      "version": "0.3.11",
-      "requires": {
-        "colors": "1.0.3"
-      }
-    },
     "cli-table3": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
@@ -8839,16 +8241,11 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "clone-response": {
-      "version": "1.0.2",
-      "requires": {
-        "mimic-response": "^1.0.0"
       }
     },
     "color-convert": {
@@ -8860,8 +8257,27 @@
     "color-name": {
       "version": "1.1.4"
     },
-    "colors": {
-      "version": "1.0.3"
+    "command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "requires": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "requires": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      }
     },
     "compare-func": {
       "version": "2.0.0",
@@ -8889,19 +8305,6 @@
           "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
           "dev": true
         }
-      }
-    },
-    "configstore": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-      "requires": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
       }
     },
     "conventional-changelog-angular": {
@@ -8963,11 +8366,10 @@
         "which": "^2.0.1"
       }
     },
-    "crypto-random-string": {
-      "version": "2.0.0"
-    },
     "dashdash": {
       "version": "1.14.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -8981,44 +8383,14 @@
         "ms": "^2.1.3"
       }
     },
-    "decompress-response": {
-      "version": "3.3.0",
-      "requires": {
-        "mimic-response": "^1.0.0"
-      }
-    },
-    "deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "requires": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      }
-    },
     "deep-extend": {
-      "version": "0.6.0"
-    },
-    "defer-to-connect": {
-      "version": "1.1.3"
-    },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
-    "delayed": {
-      "version": "2.0.0"
+      "version": "0.6.0",
+      "dev": true
     },
     "dequeue": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/dequeue/-/dequeue-1.0.5.tgz",
+      "integrity": "sha512-2FIVJZTaWhUj0Y2uKmDAasTP6ZwFWRjkRc01MYN5jFm96iIzkYyNzGADfJ13C5W7CTN7XO9mBYDcVB68eNybBA=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -9030,57 +8402,43 @@
       }
     },
     "dns-equal": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/dns-equal/-/dns-equal-1.0.0.tgz",
+      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg=="
     },
     "dns-packet": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
-      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
+      "version": "5.6.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
       "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "dns-txt": {
-      "version": "2.0.2",
-      "requires": {
-        "buffer-indexof": "^1.0.0"
+        "@leichtgewicht/ip-codec": "^2.0.1"
       }
     },
     "dot-prop": {
       "version": "5.3.0",
+      "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
       }
     },
-    "duplexer3": {
-      "version": "0.1.4"
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
     },
     "emoji-regex": {
-      "version": "8.0.0"
+      "version": "8.0.0",
+      "dev": true
     },
     "emojilib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "dev": true
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "requires": {
-        "once": "^1.4.0"
-      }
     },
     "env-ci": {
       "version": "11.2.0",
@@ -9173,10 +8531,8 @@
       }
     },
     "escalade": {
-      "version": "3.1.1"
-    },
-    "escape-goat": {
-      "version": "2.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -9226,13 +8582,10 @@
       "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
       "dev": true
     },
-    "fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "requires": {
-        "pend": "~1.2.0"
-      }
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "figures": {
       "version": "6.1.0",
@@ -9247,9 +8600,16 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "requires": {}
     },
     "find-up-simple": {
       "version": "1.0.1",
@@ -9288,15 +8648,6 @@
         "universalify": "^2.0.0"
       }
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true
-    },
-    "function-bind": {
-      "version": "1.1.1"
-    },
     "function-timeout": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
@@ -9304,21 +8655,14 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "dev": true
     },
     "get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "dev": true
-    },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -9328,81 +8672,15 @@
     },
     "getpass": {
       "version": "0.1.7",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
     },
-    "glob-parent": {
-      "version": "5.1.2",
-      "requires": {
-        "is-glob": "^4.0.1"
-      }
-    },
-    "global-dirs": {
-      "version": "3.0.0",
-      "requires": {
-        "ini": "2.0.0"
-      }
-    },
-    "got": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-      "requires": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
-      },
-      "dependencies": {
-        "cacheable-request": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-          "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-          "requires": {
-            "clone-response": "^1.0.2",
-            "get-stream": "^5.1.0",
-            "http-cache-semantics": "^4.0.0",
-            "keyv": "^3.0.0",
-            "lowercase-keys": "^2.0.0",
-            "normalize-url": "^4.1.0",
-            "responselike": "^1.0.2"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-              "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-              "requires": {
-                "pump": "^3.0.0"
-              }
-            },
-            "lowercase-keys": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-              "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
-            }
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        }
-      }
-    },
     "graceful-fs": {
-      "version": "4.2.9"
+      "version": "4.2.9",
+      "dev": true
     },
     "handlebars": {
       "version": "4.7.9",
@@ -9417,29 +8695,13 @@
         "wordwrap": "^1.0.0"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-flag": {
       "version": "4.0.0"
     },
-    "has-symbols": {
-      "version": "1.0.2"
-    },
-    "has-tostringtag": {
-      "version": "1.0.0",
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
-    },
-    "has-yarn": {
-      "version": "2.1.0"
-    },
     "hexy": {
-      "version": "0.3.2"
+      "version": "0.4.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/hexy/-/hexy-0.4.0.tgz",
+      "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg=="
     },
     "highlight.js": {
       "version": "10.7.3",
@@ -9461,9 +8723,6 @@
       "requires": {
         "lru-cache": "^11.1.0"
       }
-    },
-    "http-cache-semantics": {
-      "version": "4.1.0"
     },
     "http-proxy-agent": {
       "version": "7.0.2",
@@ -9492,7 +8751,9 @@
       "dev": true
     },
     "humanize": {
-      "version": "0.0.9"
+      "version": "0.0.9",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/humanize/-/humanize-0.0.9.tgz",
+      "integrity": "sha512-bvZZ7vXpr1RKoImjuQ45hJb5OvE2oJafHysiD/AL3nkqTZH2hFCjQ3YZfCd63FefDitbJze/ispUPP0gfDsT2Q=="
     },
     "import-fresh": {
       "version": "3.3.1",
@@ -9522,17 +8783,11 @@
         "import-meta-resolve": "^4.0.0"
       }
     },
-    "import-lazy": {
-      "version": "2.1.0"
-    },
     "import-meta-resolve": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
       "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
       "dev": true
-    },
-    "imurmurhash": {
-      "version": "0.1.4"
     },
     "indent-string": {
       "version": "5.0.0",
@@ -9550,9 +8805,6 @@
       "version": "2.0.4",
       "dev": true
     },
-    "ini": {
-      "version": "2.0.0"
-    },
     "into-stream": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
@@ -9563,70 +8815,23 @@
         "p-is-promise": "^3.0.0"
       }
     },
-    "ip": {
-      "version": "1.1.5"
-    },
-    "is-arguments": {
-      "version": "1.1.1",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "dev": true
     },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-ci": {
-      "version": "2.0.0",
-      "requires": {
-        "ci-info": "^2.0.0"
-      }
-    },
-    "is-date-object": {
-      "version": "1.0.5",
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-extglob": {
-      "version": "2.1.1"
-    },
     "is-fullwidth-code-point": {
-      "version": "3.0.0"
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-installed-globally": {
-      "version": "0.4.0",
-      "requires": {
-        "global-dirs": "^3.0.0",
-        "is-path-inside": "^3.0.2"
-      }
-    },
-    "is-npm": {
-      "version": "5.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-obj": {
-      "version": "2.0.0"
-    },
-    "is-path-inside": {
-      "version": "3.0.3"
+      "version": "2.0.0",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "4.1.0",
@@ -9634,30 +8839,17 @@
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true
     },
-    "is-regex": {
-      "version": "1.1.4",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true
     },
-    "is-typedarray": {
-      "version": "1.0.0"
-    },
     "is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "dev": true
-    },
-    "is-yarn-global": {
-      "version": "0.3.0"
     },
     "isarray": {
       "version": "1.0.0",
@@ -9704,10 +8896,9 @@
       }
     },
     "jsbn": {
-      "version": "0.1.1"
-    },
-    "json-buffer": {
-      "version": "3.0.0"
+      "version": "0.1.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -9737,37 +8928,22 @@
         "universalify": "^2.0.0"
       }
     },
-    "jsrsasign": {
-      "version": "10.5.1"
-    },
-    "keyv": {
-      "version": "3.1.0",
-      "requires": {
-        "json-buffer": "3.0.0"
-      }
-    },
-    "latest-version": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
-      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-      "requires": {
-        "package-json": "^6.3.0"
-      }
-    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
-    "lodash": {
-      "version": "4.17.21"
-    },
     "lodash-es": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "lodash.capitalize": {
       "version": "4.2.1",
@@ -9793,6 +8969,16 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true
     },
+    "lodash.partition": {
+      "version": "4.6.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/lodash.partition/-/lodash.partition-4.6.0.tgz",
+      "integrity": "sha512-35L3dSF3Q6V1w5j6V3NhNlQjzsRDC/pYKCTdYTmwqSib+Q8ponkAmt/PwEOq3EmI38DSCl+SkIVwLd+uSlVdrg=="
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+    },
     "lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
@@ -9800,19 +8986,15 @@
       "dev": true
     },
     "long": {
-      "version": "4.0.0"
-    },
-    "lowercase-keys": {
-      "version": "1.0.1"
+      "version": "5.3.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
     "lru-cache": {
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true
-    },
-    "ltx": {
-      "version": "3.0.0"
     },
     "make-asynchronous": {
       "version": "1.1.0",
@@ -9830,17 +9012,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
           "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
           "dev": true
-        }
-      }
-    },
-    "make-dir": {
-      "version": "3.1.0",
-      "requires": {
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0"
         }
       }
     },
@@ -9913,14 +9084,9 @@
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true
     },
-    "mimic-response": {
-      "version": "1.0.1"
-    },
     "minimist": {
-      "version": "1.2.5"
-    },
-    "mkdirp": {
-      "version": "1.0.4"
+      "version": "1.2.5",
+      "dev": true
     },
     "ms": {
       "version": "2.1.3",
@@ -9929,16 +9095,13 @@
       "dev": true
     },
     "multicast-dns": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
-      "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+      "version": "7.2.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
       "requires": {
-        "dns-packet": "^1.3.1",
+        "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
       }
-    },
-    "multicast-dns-service-types": {
-      "version": "1.1.0"
     },
     "mz": {
       "version": "2.7.0",
@@ -9984,1188 +9147,969 @@
       }
     },
     "node-opcua": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua/-/node-opcua-2.63.2.tgz",
-      "integrity": "sha512-kCbnm8y/S6LpIwjW4KPJu1CDTysNJRFgAPg18cZK30Yuu1hRpbuGg/knHVXaZQFPzzfNXCPkjVXxDVkD8LpdfQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua/-/node-opcua-2.175.1.tgz",
+      "integrity": "sha512-C8uVa3hzBhbu4l5SNYdpbG6ahoJmoUN/Ql+MWZI902KCSh60fsErg3KqOgWs30Lni3qU9441h/gmVnqtRTNgpQ==",
       "requires": {
+        "@types/semver": "7.7.1",
         "chalk": "4.1.2",
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-address-space-for-conformance-testing": "2.63.2",
-        "node-opcua-aggregates": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-certificate-manager": "2.63.2",
-        "node-opcua-client": "2.63.2",
-        "node-opcua-client-crawler": "2.63.2",
-        "node-opcua-client-proxy": "2.63.2",
-        "node-opcua-common": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-data-access": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-hostname": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-nodesets": "2.63.0",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-packet-analyzer": "2.63.2",
-        "node-opcua-secure-channel": "2.63.2",
-        "node-opcua-server": "2.63.2",
-        "node-opcua-server-discovery": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-discovery": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-service-node-management": "2.63.2",
-        "node-opcua-service-query": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-register-node": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-service-session": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-transport": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "node-opcua-vendor-diagnostic": "2.63.2",
-        "semver": "^7.3.5"
+        "node-opcua-address-space": "2.175.1",
+        "node-opcua-address-space-for-conformance-testing": "2.175.1",
+        "node-opcua-aggregates": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-certificate-manager": "2.175.1",
+        "node-opcua-client": "2.175.1",
+        "node-opcua-client-proxy": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-data-access": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-hostname": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-nodesets": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-packet-analyzer": "2.175.1",
+        "node-opcua-secure-channel": "2.175.1",
+        "node-opcua-server": "2.175.1",
+        "node-opcua-server-discovery": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-discovery": "2.175.1",
+        "node-opcua-service-endpoints": "2.175.1",
+        "node-opcua-service-filter": "2.175.1",
+        "node-opcua-service-history": "2.175.1",
+        "node-opcua-service-node-management": "2.175.1",
+        "node-opcua-service-query": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-register-node": "2.175.1",
+        "node-opcua-service-secure-channel": "2.175.1",
+        "node-opcua-service-session": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-transport": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1",
+        "node-opcua-vendor-diagnostic": "2.175.1",
+        "semver": "^7.8.5"
       }
     },
     "node-opcua-address-space": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-address-space/-/node-opcua-address-space-2.63.2.tgz",
-      "integrity": "sha512-2DWeyjt9QANYUnxOdK0qUSRmExJNTO+VcCrTqYBsM+F+KZXDBTgRYojICXLBeCE1VfTPsQEu17JmTdoqNN6KrQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-address-space/-/node-opcua-address-space-2.175.1.tgz",
+      "integrity": "sha512-EtNR9H56OX5E85wFT7Du/aCXLYc8pjcY74IMSajINtQHw2YqxvVTtnxBYJyt9fE7uGj4DlP2q9aKEwwcFP4Y0w==",
       "requires": {
-        "@types/lodash": "4.14.178",
-        "async": "^3.2.3",
+        "@types/semver": "7.7.1",
         "chalk": "4.1.2",
         "dequeue": "^1.0.5",
-        "lodash": "4.17.21",
-        "node-opcua-address-space-base": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-client-dynamic-extension-object": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-access": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-nodeset-ua": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pseudo-session": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "node-opcua-xml2json": "2.63.2",
-        "set-prototype-of": "^1.0.0",
-        "thenify": "^3.3.1",
+        "node-opcua-address-space-base": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-client-dynamic-extension-object": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-data-access": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-nodeset-ua": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-pseudo-session": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-history": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1",
+        "node-opcua-xml2json": "2.175.1",
+        "semver": "^7.8.5",
+        "thenify-ex": "4.4.0",
         "xml-writer": "^1.7.0"
       }
     },
     "node-opcua-address-space-base": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-address-space-base/-/node-opcua-address-space-base-2.63.2.tgz",
-      "integrity": "sha512-1YmCn0Hb00/iH0uW1vf5dKM7OPUYMxZemminZkK/C8PlMSeUjE7WMEnBKr/3wpf9dSMAwBcXYuIxIjrlokZJqw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-address-space-base/-/node-opcua-address-space-base-2.175.1.tgz",
+      "integrity": "sha512-3SCIBjJVQNpB9EqPfb+qo5U60aMAwbSrC2Tp0Kh+Qrgvm5kCWKdjvKnr8NHG7Y1fQiVXGDm3tib8BB5K83mGwQ==",
       "requires": {
-        "@types/lodash": "4.14.178",
-        "async": "^3.2.3",
-        "chalk": "4.1.2",
-        "dequeue": "^1.0.5",
-        "lodash": "4.17.21",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-client-dynamic-extension-object": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-access": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pseudo-session": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "node-opcua-xml2json": "2.63.2",
-        "set-prototype-of": "^1.0.0",
-        "thenify": "^3.3.1",
-        "xml-writer": "^1.7.0"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-schemas": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-address-space-for-conformance-testing": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-address-space-for-conformance-testing/-/node-opcua-address-space-for-conformance-testing-2.63.2.tgz",
-      "integrity": "sha512-H/7q2LmGny5EiRLZWgHdbZ8xR/nMQopgNIHQIfwTHGAaPlO+ITEu8tDZ/IdVjHq63o9NcF6N29yZoJ/tV962bA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-address-space-for-conformance-testing/-/node-opcua-address-space-for-conformance-testing-2.175.1.tgz",
+      "integrity": "sha512-MQpt0L39jbCQgTRD5tpfBD2PneDz8RTzgg9DrojKLKO339cc29CsmZVQnmrDh4v26VfXjlWlL4BGOwDM95NZXQ==",
       "requires": {
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-data-access": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-address-space": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-data-access": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-aggregates": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-aggregates/-/node-opcua-aggregates-2.63.2.tgz",
-      "integrity": "sha512-qhTQvaQLMHWiC0Jk/OpnfgdQibCj8n2GwpGmbPvscD77dPjRJzJYzMtPUwWlIHXsuVKxewfGzW7PidjoGH1nZA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-aggregates/-/node-opcua-aggregates-2.175.1.tgz",
+      "integrity": "sha512-438V0nqU2JJOrN8EVlzZQWQ55okDy3MlCRflfOHpQ8LWOKmrtjf1jdf4v6j0XC0UnomvxA997WghWpaJntMPFQ==",
       "requires": {
-        "@types/async": "^3.2.12",
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-nodesets": "2.63.0",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-address-space": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-server": "2.175.1",
+        "node-opcua-service-history": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1"
+      }
+    },
+    "node-opcua-alarm-condition": {
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-alarm-condition/-/node-opcua-alarm-condition-2.175.1.tgz",
+      "integrity": "sha512-UvP+3qQP3gosSfQpc1nNCU/9MFH9iKj095Yq4FBuzanNFsI+967DV+zaJ+eTV6M9j+l9F5h8PVc5eE2EaXr3aQ==",
+      "requires": {
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-pseudo-session": "2.175.1",
+        "node-opcua-service-filter": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-assert": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-assert/-/node-opcua-assert-2.63.0.tgz",
-      "integrity": "sha512-ZyiaiumumUtiXr82FsjrO1reP/Nf487Mztoz4CZ6X+wVSHQywXb8YUKsTAv3e0cAzjPK6mwXneALxxtCVWANVA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-assert/-/node-opcua-assert-2.175.1.tgz",
+      "integrity": "sha512-xSHHApbeJW1IhRKDUwSac0S00zfOuWsiMpTfCXU5IZiE4bzWTOV82VFVv9jA+mt5nklb/t60+VxjhwJWxDO+hg==",
       "requires": {
-        "better-assert": "^1.0.2",
         "chalk": "4.1.2"
       }
     },
     "node-opcua-basic-types": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-basic-types/-/node-opcua-basic-types-2.63.2.tgz",
-      "integrity": "sha512-G5FtBhCREIn1k3xuxczTh18U8QT6dzt8AU8SQwmBCWmtK6XPlrZm3L5QF2o+hI0nxYniHRxa9ygKC02fSuansQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-basic-types/-/node-opcua-basic-types-2.175.1.tgz",
+      "integrity": "sha512-OkiWY8jpknBANBA+K1zZ+sOc8o0mGTsP+eAplZMdiP7Jav5YQS6cI92/Y/0plfpHUQuPXFxzdTceDeM38OZodA==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-guid": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-buffer-utils": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-guid": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-status-code": "2.175.1"
       }
     },
     "node-opcua-binary-stream": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-binary-stream/-/node-opcua-binary-stream-2.63.2.tgz",
-      "integrity": "sha512-Y5oJI53L9UXwuxB2RSNBtL5kMb/gFW/WbCiQaF6B4+0z3rlMjEVLaPGP3sIJYE1EfsNnecar2CotKRoO+/ur0w==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-binary-stream/-/node-opcua-binary-stream-2.175.1.tgz",
+      "integrity": "sha512-OORZZs6bg5RUMffhRUBDD4tZRWamCMCP1Olf/Y/k7GHvpT5RVwaHHYxDIWg8zng/0UxGyWktE6u2aleMyXG7sg==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-buffer-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-buffer-utils": "2.175.1"
       }
     },
     "node-opcua-buffer-utils": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-buffer-utils/-/node-opcua-buffer-utils-2.63.2.tgz",
-      "integrity": "sha512-yi4mbZEmc9fbFUaIiGu3BlTLlgCrYmVI+WjGfjrY8ZcyvX/2ssFm3WJQn0k6JfyQYqNcf7CsNOfKHAymS/nl8Q==",
-      "requires": {
-        "node-opcua-assert": "2.63.0"
-      }
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-buffer-utils/-/node-opcua-buffer-utils-2.175.1.tgz",
+      "integrity": "sha512-j0fQ7zJaw7bbxylo6syU1+6KJVD/dshIQYNJmR3z3uy7q7M7xnpinHRkdJU3bBCJk4tURjHorIFIZUzN0qt3Jg=="
     },
     "node-opcua-certificate-manager": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-certificate-manager/-/node-opcua-certificate-manager-2.63.2.tgz",
-      "integrity": "sha512-diRpWwh4VefASCMvS06H1bXpB/QOAUu7vfk/YRrm5hLDrgL9RkLwQ5QPkQqmDkk78046bp3TH15J4KDg1MC9zw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-certificate-manager/-/node-opcua-certificate-manager-2.175.1.tgz",
+      "integrity": "sha512-u+MUjzQVX+lim/COQgYgpI6LyVOJt+GUZkN7Sdx1zvfaxEZ3Iu0yV0+FLnCe4zSPwz5aCtuYPQpn819tVuw4Cw==",
       "requires": {
-        "@types/mkdirp": "1.0.1",
-        "chalk": "4.1.2",
-        "delayed": "^2.0.0",
         "env-paths": "2.2.1",
-        "mkdirp": "1.0.4",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pki": "^2.13.0",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "once": "^1.4.0",
-        "thenify": "^3.3.1"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-pki": "6.18.0",
+        "node-opcua-status-code": "2.175.1",
+        "thenify-ex": "4.4.0"
       }
     },
     "node-opcua-chunkmanager": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-chunkmanager/-/node-opcua-chunkmanager-2.63.2.tgz",
-      "integrity": "sha512-aHRXmd6ibsxxqdZetDhvYCv9fEf8xL+U2V98J6NFawcMl644XX5g3TQGOXDf031Yt4sGQM9+DeDcENbgXk6kzA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-chunkmanager/-/node-opcua-chunkmanager-2.175.1.tgz",
+      "integrity": "sha512-3mfvJMPIfnFF0pL9flo2gGrU3sS1YuKaHFGdNEvi7iCaqebcVp+IoZJ0BfJW1S793jM78O4kV/kmFitCEHQfDw==",
       "requires": {
-        "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-packet-assembler": "2.63.0"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-buffer-utils": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-packet-assembler": "2.175.1"
       }
     },
     "node-opcua-client": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-client/-/node-opcua-client-2.63.2.tgz",
-      "integrity": "sha512-oS/T8gZs5GpSlpSjOHR9bFThMql861Li87tvq3MdGhcIcRrzQWSRgmCsdb3sAOzxLXR6JFIAH0ffNp/SX0DZqA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-client/-/node-opcua-client-2.175.1.tgz",
+      "integrity": "sha512-fXrsFe2lK9sFIH0HdE0EGQg1PgzhG/V6f1abVun03XZbj8sb2flwNYZrr0fkqzx3MuZLDVZjtzTt3mnu7XQZkA==",
       "requires": {
-        "@ster5/global-mutex": "^1.2.0",
-        "@types/async": "^3.2.12",
-        "@types/once": "^1.4.0",
-        "@types/underscore": "^1.11.4",
-        "async": "^3.2.3",
-        "callbackify": "^1.1.0",
+        "@ster5/global-mutex": "^3.3.0",
         "chalk": "4.1.2",
-        "delayed": "^2.0.0",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-certificate-manager": "2.63.2",
-        "node-opcua-client-dynamic-extension-object": "2.63.2",
-        "node-opcua-common": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-hostname": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pki": "^2.13.0",
-        "node-opcua-pseudo-session": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-secure-channel": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-discovery": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-service-query": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-register-node": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-service-session": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "once": "^1.4.0",
-        "thenify": "^3.3.1",
-        "underscore": "^1.13.2"
-      }
-    },
-    "node-opcua-client-crawler": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-client-crawler/-/node-opcua-client-crawler-2.63.2.tgz",
-      "integrity": "sha512-q/47BmNc0hgCOakYaDgM1AvWd02H7/SDS71SJtXcOX8pUIDtV5CboeWWYaR473fJJDLRSHMC8DaRwanfiqTo7Q==",
-      "requires": {
-        "@types/underscore": "^1.11.4",
-        "async": "^3.2.3",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "underscore": "^1.13.2"
+        "node-opcua-alarm-condition": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-buffer-utils": "2.175.1",
+        "node-opcua-certificate-manager": "2.175.1",
+        "node-opcua-client-dynamic-extension-object": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-hostname": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-pki": "6.18.0",
+        "node-opcua-pseudo-session": "2.175.1",
+        "node-opcua-schemas": "2.175.1",
+        "node-opcua-secure-channel": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-discovery": "2.175.1",
+        "node-opcua-service-endpoints": "2.175.1",
+        "node-opcua-service-filter": "2.175.1",
+        "node-opcua-service-history": "2.175.1",
+        "node-opcua-service-query": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-register-node": "2.175.1",
+        "node-opcua-service-secure-channel": "2.175.1",
+        "node-opcua-service-session": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-transport": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1",
+        "thenify-ex": "4.4.0"
       }
     },
     "node-opcua-client-dynamic-extension-object": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-client-dynamic-extension-object/-/node-opcua-client-dynamic-extension-object-2.63.2.tgz",
-      "integrity": "sha512-wFcQuc5x9pMB7lY/mydXNp9zrFryslr8UW4xzqwcy+nP9sKWgKrHGCDqso3zKks8IrQ24wzxm/B1/hvlhupb5g==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-client-dynamic-extension-object/-/node-opcua-client-dynamic-extension-object-2.175.1.tgz",
+      "integrity": "sha512-jtGfH0HaTKxSGRUNR0DVvJwddUOY3VYNbxAFKbAvWaDliA+pO0sbPl++V19SMVo9ahbPcRz/LLxeeoqZmDi5QQ==",
       "requires": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-pseudo-session": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-pseudo-session": "2.175.1",
+        "node-opcua-schemas": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-client-proxy": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-client-proxy/-/node-opcua-client-proxy-2.63.2.tgz",
-      "integrity": "sha512-fxPHiRXSW+bg2affcc+rfNQjV2Oca9zz+iLqa17MpHTW4hNFxPKxVfsW6banSo8n0TNPOpbC6kETee34WWebAQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-client-proxy/-/node-opcua-client-proxy-2.175.1.tgz",
+      "integrity": "sha512-+Fge1kFcTERAYyhCb+A1VoWxLGB463uA8tIoKdwPaDNHHqcVwMWqCk3N6WIMPFRbvASB79WvaHxk8U6uArv/TQ==",
       "requires": {
-        "async": "^3.2.3",
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-pseudo-session": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-pseudo-session": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-common": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-common/-/node-opcua-common-2.63.2.tgz",
-      "integrity": "sha512-QX+MSOF1e4sg49Ct/cd0zXE2nUgMxgsPRQNEW12L7Rs2kglYaNXi6U7YtINET2KNtx1vqZiTB19j5TFv0Xe63w==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-common/-/node-opcua-common-2.175.1.tgz",
+      "integrity": "sha512-/pfuBAeN/BCawJ7eSsQQOBeD6sS4eEng9234edqzYcQusN3juXGsyARdUpiE2y19NB7X8sn9FklAQiVYLjGP8g==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-constants": {
-      "version": "2.62.7"
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-constants/-/node-opcua-constants-2.175.1.tgz",
+      "integrity": "sha512-o3icxyhe18cWRWefAa39saAYaPkPx/UmscFOOoZXX37BLcNiH7WNmfJ1T89rdtkDfVqkLXKWyh5ObzOKSohSig=="
     },
     "node-opcua-crypto": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/node-opcua-crypto/-/node-opcua-crypto-1.7.5.tgz",
-      "integrity": "sha512-4JBgUEV0pV5QaFmLVCr22JRGLLJ1rwPSNcKolD7OBOrdmG2OAqD/gsLojAYKeh/nuowv4Sx93j9NZ3pfBzaqrQ==",
+      "version": "5.3.6",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-crypto/-/node-opcua-crypto-5.3.6.tgz",
+      "integrity": "sha512-XXfdMZhXgN8Epf2tJLpQ1a2v/AKa/E+qvaaFXt1wP5ElL1ImU0vs+qxvY3j+Bemz/aob6aelHVrNq1eVU2Fqng==",
       "requires": {
-        "better-assert": "^1.0.2",
-        "chalk": "^4.1.2",
-        "hexy": "0.3.1",
-        "jsrsasign": "^10.4.0",
-        "sshpk": "^1.16.1"
-      },
-      "dependencies": {
-        "hexy": {
-          "version": "0.3.1"
-        }
+        "@peculiar/webcrypto": "^1.7.1",
+        "@peculiar/x509": "^2.0.0",
+        "reflect-metadata": "^0.2.2",
+        "sshpk": "^1.18.0"
       }
     },
     "node-opcua-data-access": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-data-access/-/node-opcua-data-access-2.63.2.tgz",
-      "integrity": "sha512-SsVRma+5rWFzF4XFWjlQ12F+XTlVgG3qKLc4tSq3F5QWT8Ts4uY4V4y+hNz8AE2SGa9Wn1IxY8lVVvYJJJV5cg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-data-access/-/node-opcua-data-access-2.175.1.tgz",
+      "integrity": "sha512-Y2trw/Wal0TboNipmeJ9VWr5p8xNHGAP1HnWks/mdoyqKcNNNc9Alz0w1/Rpevm5fX/1Si7Wp+S4iQspHZJJ3A==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-data-model": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-data-model/-/node-opcua-data-model-2.63.2.tgz",
-      "integrity": "sha512-xFi42EEZRLkXDxA2Y/oFtf2n2Vqk6Ek38e22Mrd6ZLykNgp7omyOw9Nb6BuY+ef6ne8JSPEokaePmryzEBOkYQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-data-model/-/node-opcua-data-model-2.175.1.tgz",
+      "integrity": "sha512-cCjorTjSH3iC9zE8LOb1pyRcl5UEn6bpnzn80VMr5CcLh7uCd+6stgol9Nkr7NglXghWtTqoqyeka69qVUwC8Q==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-status-code": "2.175.1"
       }
     },
     "node-opcua-data-value": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-data-value/-/node-opcua-data-value-2.63.2.tgz",
-      "integrity": "sha512-vmzkEFoQCNBXGMPHepCorA8Xl2Z4N9FweVFhTJupHaTeVgSgnVNkUn8nY0JB2rpDr/ZnduS/JyVghip2nPq4/A==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-data-value/-/node-opcua-data-value-2.175.1.tgz",
+      "integrity": "sha512-9tkQwc/I/HOyJWIB9j23PsTkuqHkV5DZymllw3oz/lNhYPPwEucS9LBwqUaJSodo69YNWTA1yz16aHqgbrJn7A==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-date-time": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-date-time/-/node-opcua-date-time-2.63.2.tgz",
-      "integrity": "sha512-8xGOJ/drfLXmP4ozYm4rYc1+kKOev/uT9NQzAnVah3s9ZCBuQkEkONZ29Hipj+GDwLJ8RfvvjbT6YtrYIb/ZHA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-date-time/-/node-opcua-date-time-2.175.1.tgz",
+      "integrity": "sha512-ngj2T6NA3ZufMxZcPyoHsNOCvS0wBx/VXVf0qjcrHFF9d/rAoCrAWJ5lhvzq8wN9RVXzqQ9XspdAo4bawKOFNA==",
       "requires": {
-        "long": "^4.0.0",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-utils": "2.63.2"
+        "long": "5.3.2",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node-opcua-debug": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-debug/-/node-opcua-debug-2.63.2.tgz",
-      "integrity": "sha512-BnFJUDfRyMDMKT8GxKB73DGXBxqWxp2UP4Ds7YhEW0RMdouFmB7N1fmKcjR+VqKX+jFVclGQDCWRNdkBGDeS3g==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-debug/-/node-opcua-debug-2.175.1.tgz",
+      "integrity": "sha512-ppDqzEz03rldixADuypjEa/UXUJXKQoYkjigavFXtruE8IcJ+afIxZR8qOYMdw646+BvbLF4mABog32TIV5OnQ==",
       "requires": {
-        "hexy": "0.3.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-buffer-utils": "2.63.2"
+        "chalk": "4.1.2",
+        "hexy": "0.4.0",
+        "node-opcua-assert": "2.175.1"
       }
     },
     "node-opcua-enum": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-enum/-/node-opcua-enum-2.63.2.tgz",
-      "integrity": "sha512-6pDlxO0OUnG/rtmbEAbsOwIhdEPYDi84N2XeNlqqQouWuWnViNwo5wtoD6+ZzzFpksawDf2RyTdTGwWXCO0JWw==",
-      "requires": {
-        "node-opcua-assert": "2.63.0"
-      }
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-enum/-/node-opcua-enum-2.175.1.tgz",
+      "integrity": "sha512-IitPGibF9o8MClF1fDR7euxwl7dqVxqwjn8Rwv/CxLSpnlVKx9VUIqucuuIgvfEjb4NtwZ5r/Gb8noWUd3sBXQ=="
     },
     "node-opcua-extension-object": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-extension-object/-/node-opcua-extension-object-2.63.2.tgz",
-      "integrity": "sha512-yzZBwg0m3oHWFpLGihyyseuNrXCS9Grw/QlbEmD5nBzodgHFUoOehmIuTEcpYLU/oI04aN2e4WWL7GaH9u/OXg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-extension-object/-/node-opcua-extension-object-2.175.1.tgz",
+      "integrity": "sha512-wtGGwBgwONfAvsLXRcrA3VuMGxLv7o3qQGvEA20CZMCigny+Q4N/aPOhKjTrX+zcbrAbmV0oK/EMABSfHd+Xjw==",
       "requires": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2"
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1"
       }
     },
     "node-opcua-factory": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-factory/-/node-opcua-factory-2.63.2.tgz",
-      "integrity": "sha512-0x3xOMSRqY8JjZpfQXLRX+gtaLlhXPq8D8tE2BRO1kgbrQEIS9hvk8dapwVzJ8ngqFn8nxmlnCzyFMdvCwc5IA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-factory/-/node-opcua-factory-2.175.1.tgz",
+      "integrity": "sha512-IZ1tm4PhFyCKNdE69IQ+2Fab5QP1RR5N6eUjmLYuzRkvSUg3o8fBvU7XYydGiaDVYGfDZg6og/eW8YVdePk/Jw==",
       "requires": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-guid": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2"
-      }
-    },
-    "node-opcua-generator": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-generator/-/node-opcua-generator-2.63.2.tgz",
-      "integrity": "sha512-w6BYAxFeDDOOFyF1I+3v9lYH5tnCnBiXZnTq4j1Ts/c9ZDnfreBLaH5QkWERqZA15XRV+5hinACt9FQr24+tBQ==",
-      "requires": {
-        "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-guid": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "node-opcua-xml2json": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-guid": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node-opcua-guid": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-guid/-/node-opcua-guid-2.63.0.tgz",
-      "integrity": "sha512-ip/AFOjYtjRhowoF0zxu7TJKBgOlRKsuY77FCurMHKvPdqWNuvVzaYRzEZuvs+whKOgvVv95bx4SMJyjknyIYw==",
-      "requires": {
-        "node-opcua-assert": "2.63.0"
-      }
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-guid/-/node-opcua-guid-2.175.1.tgz",
+      "integrity": "sha512-NFaMaqd4IflvzImukSloM3Sf5tohIdh+m2OvEfkWA54pzZOebayXwgYHK3IkY16Ey2YWSSmSx7SfLWmjVbUYxw=="
     },
     "node-opcua-hostname": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-hostname/-/node-opcua-hostname-2.63.0.tgz",
-      "integrity": "sha512-mT1CbSiEBci0JZZEgEYwpUUPp06rVYNJWrvXMKiSW1oVaVdqlpnlLUOBl4koc1e5zfikTtfhCl1H1ZnI+rRrkA==",
-      "requires": {
-        "node-opcua-assert": "2.63.0"
-      }
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-hostname/-/node-opcua-hostname-2.175.1.tgz",
+      "integrity": "sha512-boaF8hm56sQjUqf0jkYBmnkc4VjvFwZTKffs5hVLiT+MyW8NXQkIkjlLm/kjNIr4YWnHrVYMb7UI8slJ54xVZA=="
     },
     "node-opcua-nodeid": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-nodeid/-/node-opcua-nodeid-2.63.2.tgz",
-      "integrity": "sha512-7TdwfnmVaagmcp0dNsXibe22iKfxTWGX8vcQ+3prx4WY5thfj+gAJtbzuost16SHuH3Dh/vqlP6HXsSYbRoTjg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-nodeid/-/node-opcua-nodeid-2.175.1.tgz",
+      "integrity": "sha512-aHRMKI2ruyQCh31THy8gL5ukul+uA3fZKsKt7Fmah174JhxNrjDcKL73K/YTn5sMxhrAsS6vsbxtWN57zVgCdA==",
       "requires": {
-        "@types/lodash": "4.14.178",
-        "chalk": "4.1.2",
-        "lodash": "4.17.21",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-guid": "2.63.0"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-guid": "2.175.1"
       }
     },
     "node-opcua-nodeset-ua": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-nodeset-ua/-/node-opcua-nodeset-ua-2.63.2.tgz",
-      "integrity": "sha512-6BkXJu8F0c2UaW/+l6ynYJW4h5waM3bV/8H1f9UNanX7AawryepAd+SJfssMV9EvO+1Gb8UucjluWpz7runYtQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-nodeset-ua/-/node-opcua-nodeset-ua-2.175.1.tgz",
+      "integrity": "sha512-pgYIgg4MS6SAgCXHOr4hG7u4zE+BdNlV0IJXpXB7HJeEtDymnO/ie3hoWdh6gvWm+mYnZZKHURgBgzvlQdUASQ==",
       "requires": {
-        "node-opcua-address-space-base": "2.63.2",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-data-access": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-address-space-base": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-data-access": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-nodesets": {
-      "version": "2.63.0"
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-nodesets/-/node-opcua-nodesets-2.175.1.tgz",
+      "integrity": "sha512-4u/lrw8BOHhInw9aWmiQW657NUgbHOLmifnBY+QU4kwjZ92QshrmSLXTVLDj3V7s0krw+Rzyrqyrkhn7I0+UEg=="
     },
     "node-opcua-numeric-range": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-numeric-range/-/node-opcua-numeric-range-2.63.2.tgz",
-      "integrity": "sha512-o/qFWlIgnsHjC/yvQf/JVWbBDYLOyWYGQl7yH/wSzQqgUOsm+L6gEUJv5K9XNx07SGcCV/KBQOfyuz/kYTsp/w==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-numeric-range/-/node-opcua-numeric-range-2.175.1.tgz",
+      "integrity": "sha512-zYToOjPBn7BalZzOcLPnQINWSPBJTqYdp0W9GtRby6zx2hHa95dgQ5YsD6IIxLPVCQY/k92axsDOIednI7IWZA==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-status-code": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-status-code": "2.175.1"
       }
     },
     "node-opcua-object-registry": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-object-registry/-/node-opcua-object-registry-2.63.2.tgz",
-      "integrity": "sha512-AL9qvFxk+5r8qSotBqLTJGI8xo43lX1MR+bEdF2soMoghvn9hz3pHaSEeXCXb7YAGLghBMCgbx5VZGZF7i7piw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-object-registry/-/node-opcua-object-registry-2.175.1.tgz",
+      "integrity": "sha512-bG1WqH/dXaaUw+tu/L+s6WgroPCqP7QAkfYppVOe9FcV074G5BXr1Ddf8PlLqxvdnouDrf7+0JBjc+zjiGn8Ew==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-debug": "2.63.2"
+        "node-opcua-debug": "2.175.1"
       }
     },
     "node-opcua-packet-analyzer": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-packet-analyzer/-/node-opcua-packet-analyzer-2.63.2.tgz",
-      "integrity": "sha512-+zgPnby9XEnHCAJSwIDeBwLmD8+mwduQBkSIP/PHVJ32JuOmOnkq+iXBZYrjRQ4oG9Wmdqtu/j7h7MHa5Esjeg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-packet-analyzer/-/node-opcua-packet-analyzer-2.175.1.tgz",
+      "integrity": "sha512-0fsAzQNm95aVxI77KMTn5wly5522gUvDf2P7IMZE01TIz4p1QFsWDPtuB+ajHILgLyLcW+E8XguJ1NJp4fZjeA==",
       "requires": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node-opcua-packet-assembler": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-packet-assembler/-/node-opcua-packet-assembler-2.63.0.tgz",
-      "integrity": "sha512-v+aFpIhJZIompyqXiQNrCg4yjYq+oC7LsBQdxyIWZhv3t/hzC9NJ9MI+sAd4YmOaRHkx9ORKRjhsUjvE4KRnVg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-packet-assembler/-/node-opcua-packet-assembler-2.175.1.tgz",
+      "integrity": "sha512-pZzh83GWZukdYEIoYiOX7TgcnU8Ldpi8rjjLXkak8mc7cDzeF6TWdffH5kCStRBX5CzvcpdpUB+O/+eo62MlwA==",
       "requires": {
-        "node-opcua-assert": "2.63.0"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-debug": "2.175.1"
       }
     },
     "node-opcua-pki": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-pki/-/node-opcua-pki-2.13.0.tgz",
-      "integrity": "sha512-qi0x36RaGG246Le0XrKbq51IU12d6oBeEqABwVV9ivoWvEa8tvedurc2eblpIZvjErFxKb9g4L3gQa0zOBIuyA==",
+      "version": "6.18.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-pki/-/node-opcua-pki-6.18.0.tgz",
+      "integrity": "sha512-y3BKrgo9LYDUkP1pcpmAzZDXJJXr/h464XV6PhVXjibrQOAXPW3oPk75WzVZNl6OLUtEp4WXn3RxwQ2RtJM9yQ==",
       "requires": {
-        "@ster5/global-mutex": "^1.2.0",
+        "@ster5/global-mutex": "^3.3.0",
         "byline": "^5.0.0",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.2",
-        "cli-table": "^0.3.9",
-        "node-opcua-crypto": "^1.8.0",
-        "progress": "^2.0.3",
-        "thenify": "^3.3.1",
-        "update-notifier": "5.1.0",
-        "wget-improved": "^3.2.1",
-        "yargs": "17.2.1",
-        "yauzl": "^2.10.0"
-      },
-      "dependencies": {
-        "node-opcua-crypto": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/node-opcua-crypto/-/node-opcua-crypto-1.8.0.tgz",
-          "integrity": "sha512-rFFsDKAJg1rxoSCXZ2JOTybyC+Aw/jLm8ksiiROX69ZZoFw9rgoA+Ohiue8fK7Dt0+FjTMBZf0gqOuFXmIbiDg==",
-          "requires": {
-            "better-assert": "^1.0.2",
-            "chalk": "^4.1.1",
-            "hexy": "^0.3.1",
-            "jsrsasign": "^10.2.0",
-            "sshpk": "^1.16.1"
-          }
-        }
+        "chalk": "4.1.2",
+        "chokidar": "4.0.3",
+        "command-line-args": "^6.0.2",
+        "command-line-usage": "^7.0.4",
+        "node-opcua-crypto": "5.3.6",
+        "yauzl": "^3.3.0"
       }
     },
     "node-opcua-pseudo-session": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-pseudo-session/-/node-opcua-pseudo-session-2.63.2.tgz",
-      "integrity": "sha512-8An89bWF2f4CIIU4inu/PLMGhK2iAepwLPvc29iV9sYfbYbpeaaJCfUSvpWOtruzhc0Pew2hr5evl+C6i7Exfw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-pseudo-session/-/node-opcua-pseudo-session-2.175.1.tgz",
+      "integrity": "sha512-w2tyiqmZDQVo4/4YPjGjAJ688AxzOaQE0s5AHDnKFFYWmC1nq4LdhrYyAg1Vf1L+p8lNyB3KHn9UN1OKxCCcmw==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-schemas": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-schemas/-/node-opcua-schemas-2.63.2.tgz",
-      "integrity": "sha512-SL/M62RCylprfbsa4mFfXSA7fcRn1BkM77eL+ASrZ0F/4FiM7Yv2ySrBK7WgmzVDZnuyjkVijLjiAJVBVUXeaA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-schemas/-/node-opcua-schemas-2.175.1.tgz",
+      "integrity": "sha512-Kcg2IcSjwdoRK0m5CRyX/kgW8hr40LQY+VhjygbH5wePMyTRF5H1iGmpPnGY86GYXK4Hdib6u0InEwSSpdLdLg==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2",
-        "node-opcua-xml2json": "2.63.2",
-        "thenify": "^3.3.1"
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-variant": "2.175.1",
+        "node-opcua-xml2json": "2.175.1"
       }
     },
     "node-opcua-secure-channel": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-secure-channel/-/node-opcua-secure-channel-2.63.2.tgz",
-      "integrity": "sha512-JXMFPvKnsFLrL9SsSb9rxQ4mimwY3X49hn0bFkUoqrzWhIiZvVlE6Bs0NW8hXms7eUnS2qVUlFdUv2zJywTylQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-secure-channel/-/node-opcua-secure-channel-2.175.1.tgz",
+      "integrity": "sha512-xJeZvj6RX1wXWLU1NTi2wnHHvIayUP3chPZxHYzTVX3Aw+wWbGu8ghXNKEr7htoLk/p9Mr7gPIVWnCMxxVeqxw==",
       "requires": {
-        "@types/underscore": "1.11.4",
-        "async": "^3.2.3",
         "backoff": "^2.5.0",
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-certificate-manager": "2.63.2",
-        "node-opcua-chunkmanager": "2.63.2",
-        "node-opcua-common": "2.63.2",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-packet-analyzer": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-transport": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-chunkmanager": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-packet-analyzer": "2.175.1",
+        "node-opcua-service-endpoints": "2.175.1",
+        "node-opcua-service-secure-channel": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-transport": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node-opcua-server": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-server/-/node-opcua-server-2.63.2.tgz",
-      "integrity": "sha512-mN4375Qml5RlH2MFh2oTDJg5JbdFV1KsSuK85gQMXg5h2B8GA5oXJPd2j6IWoBHIjC85Z8hHKOUPcyTdPn1Kvw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-server/-/node-opcua-server-2.175.1.tgz",
+      "integrity": "sha512-GhXroHlCE0N4xXoV1sM5IJKl4mO3HnOfSGC6AxNucW5zJZERX5r5hod2ZWE1WlsJ/m+INT2dlepKZfGyUzu42Q==",
       "requires": {
-        "@ster5/global-mutex": "^1.2.0",
-        "@types/underscore": "^1.11.4",
-        "async": "^3.2.3",
-        "bonjour": "^3.5.0",
+        "@ster5/global-mutex": "^3.3.0",
+        "chalk": "4.1.2",
         "dequeue": "^1.0.5",
-        "lodash": "4.17.21",
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-certificate-manager": "2.63.2",
-        "node-opcua-client": "2.63.2",
-        "node-opcua-client-dynamic-extension-object": "2.63.2",
-        "node-opcua-common": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-crypto": "^1.7.5",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-hostname": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-nodesets": "2.63.0",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pki": "^2.13.0",
-        "node-opcua-secure-channel": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-call": "2.63.2",
-        "node-opcua-service-discovery": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-history": "2.63.2",
-        "node-opcua-service-node-management": "2.63.2",
-        "node-opcua-service-query": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-register-node": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-service-session": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-service-write": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "lodash.partition": "^4.6.0",
+        "lodash.sortby": "^4.7.0",
+        "node-opcua-address-space": "2.175.1",
+        "node-opcua-address-space-base": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-certificate-manager": "2.175.1",
+        "node-opcua-client": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-crypto": "5.3.6",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-date-time": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-hostname": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-nodesets": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-pki": "6.18.0",
+        "node-opcua-secure-channel": "2.175.1",
+        "node-opcua-service-browse": "2.175.1",
+        "node-opcua-service-call": "2.175.1",
+        "node-opcua-service-discovery": "2.175.1",
+        "node-opcua-service-endpoints": "2.175.1",
+        "node-opcua-service-filter": "2.175.1",
+        "node-opcua-service-history": "2.175.1",
+        "node-opcua-service-node-management": "2.175.1",
+        "node-opcua-service-query": "2.175.1",
+        "node-opcua-service-read": "2.175.1",
+        "node-opcua-service-register-node": "2.175.1",
+        "node-opcua-service-secure-channel": "2.175.1",
+        "node-opcua-service-session": "2.175.1",
+        "node-opcua-service-subscription": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-service-write": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-transport": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-utils": "2.175.1",
+        "node-opcua-variant": "2.175.1",
+        "thenify-ex": "4.4.0"
       }
     },
     "node-opcua-server-discovery": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-server-discovery/-/node-opcua-server-discovery-2.63.2.tgz",
-      "integrity": "sha512-Hizmzl5f6clR/D/rmV0aAQWv9SeAL3lxLqv35vuRBQwy+BPZddsIORHq3AgjssOQfT8KsLWSYR5jWra4BbOF6A==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-server-discovery/-/node-opcua-server-discovery-2.175.1.tgz",
+      "integrity": "sha512-IhGRA+zdw0TeiKIziO7CLYhKjtD8cTAsa7S74/hG4Ut8cTqfoAoAR+e3Ix9RKRynXemdemMG8f5Iajya0OWQgg==",
       "requires": {
-        "@types/bonjour": "^3.5.10",
-        "bonjour": "^3.5.0",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-certificate-manager": "2.63.2",
-        "node-opcua-common": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-hostname": "2.63.0",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-pki": "^2.13.0",
-        "node-opcua-secure-channel": "2.63.2",
-        "node-opcua-server": "2.63.2",
-        "node-opcua-service-discovery": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-status-code": "2.63.2"
+        "chalk": "4.1.2",
+        "env-paths": "2.2.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-certificate-manager": "2.175.1",
+        "node-opcua-common": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-secure-channel": "2.175.1",
+        "node-opcua-server": "2.175.1",
+        "node-opcua-service-discovery": "2.175.1",
+        "node-opcua-service-endpoints": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "sterfive-bonjour-service": "1.1.4",
+        "thenify-ex": "4.4.0"
       }
     },
     "node-opcua-service-browse": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-browse/-/node-opcua-service-browse-2.63.2.tgz",
-      "integrity": "sha512-bKGO0B9FNFZ2k+7QsLairLnsb9LEcgag8BFCkTIDGb4GY8ca4QCWpNj4kKuPUAzw2xz+ZZBrpwmd0Bij0VtBiQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-browse/-/node-opcua-service-browse-2.175.1.tgz",
+      "integrity": "sha512-HnTq2DHTYs9YBvQfjns2Ux5tXY/H0pIOwzpuK6NvL55ZoNyd5KReub2MM5s9DQSGUW36ggBRTCLr5YMjzzH4yA==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-service-call": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-call/-/node-opcua-service-call-2.63.2.tgz",
-      "integrity": "sha512-Tsjyu+k0G0a7tF/nRkFx+k+3ggKmBLF8YGbmSbVkrHdE0y7BSu+7YR9A968IvDJ18n96TfbRgDGZZdGS9dJfKw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-call/-/node-opcua-service-call-2.175.1.tgz",
+      "integrity": "sha512-URaWpLorjBj4mOHWnXPsnTRDJJtyl6u271iDAEUyNHA2RYlwlRG/JnQ+t0lQF11ru1W0MnSFrJ8HDPeV0NGuEw==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-service-discovery": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-discovery/-/node-opcua-service-discovery-2.63.2.tgz",
-      "integrity": "sha512-/xmObzr+bMsY4CBP/rrBtC2xLst98IAvZDB98IWebqBgqZdheA5UZ39kryUzbaZHUx4eGEFoReC6aRYAOOH20A==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-discovery/-/node-opcua-service-discovery-2.175.1.tgz",
+      "integrity": "sha512-Afx3hvTTz5vjtuOLElcF8VzdU50xIJC0c/LBokqQ8W2iJ+gS1uutkFr/2dEIoNmV+U3inqWmgxOmn7X4BTTb3A==",
       "requires": {
-        "@types/bonjour": "^3.5.10",
-        "bonjour": "^3.5.0",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "chalk": "4.1.2",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "sterfive-bonjour-service": "1.1.4"
       }
     },
     "node-opcua-service-endpoints": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-endpoints/-/node-opcua-service-endpoints-2.63.2.tgz",
-      "integrity": "sha512-fmF5JRmVKSHQwMLxEIuA+DyIMeZk9sJRgGxh+OtEYXNwPmgteoRhAKO5Oun33TQGvtNpgoAkTHXkZztUEUwyNg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-endpoints/-/node-opcua-service-endpoints-2.175.1.tgz",
+      "integrity": "sha512-j7SHDmq4e5cUY20nCy9tDa8U+rtARh9Z5FPXxcwLbdENu52h04ml8SaJgaz1Idj3/iOHB6o5rTL2BZaob3oOhg==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-service-filter": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-filter/-/node-opcua-service-filter-2.63.2.tgz",
-      "integrity": "sha512-oYmeOzRKbVj1r8/NnxnW+iYbjLjnqvOpKVp1hlqBfbF4tm1/NI/ngSrtq07Wn1NXdV/V0OzXiCYjAsyjqmC5cA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-filter/-/node-opcua-service-filter-2.175.1.tgz",
+      "integrity": "sha512-Xw6CKS7NqbnDPG7Y9NjRV/F9b+lmMNLJ6mPyr1WZDkkYuyM+NsU0xg0GjnCG9Ro99OBgzu6IZUIRImhSr4gjYw==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-address-space-base": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-service-translate-browse-path": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-service-history": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-history/-/node-opcua-service-history-2.63.2.tgz",
-      "integrity": "sha512-EIfHKq94A1p+wGKLbD8u0MDgYrCw2Qy+xcooE0MAuZ3viNuEItRq9uu/a9GpVlwDfueEWbEQcU1C4EbFZ6PjSA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-history/-/node-opcua-service-history-2.175.1.tgz",
+      "integrity": "sha512-YUfp9Z/W4/PqKUrMOIikgXYyugax8YH3NdsHQbCd+BbFlzujlaM63Qmmd7iFDW0SzSRduhMWymOi5l69mZBwGA==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-service-node-management": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-node-management/-/node-opcua-service-node-management-2.63.2.tgz",
-      "integrity": "sha512-3dP67VJOqdu+phHgDkI6t/3UFWHJwisv2acxAiMU9Ue+hTAYgGzibANIl+Fl1jT+pxsInDROMvXuEnC7HphkNA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-node-management/-/node-opcua-service-node-management-2.175.1.tgz",
+      "integrity": "sha512-y+wJlNpkbcsie4cRG7YPELUD1VIFKr/oVNPGHMM2fEnsy7inSSNz0dH9BCEu/E3MxFMq+iKWen4GUN0zSQCmJA==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-service-query": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-query/-/node-opcua-service-query-2.63.2.tgz",
-      "integrity": "sha512-MBVAPhL2l2THiUcLNI2DYw6MC7JD/2+yhLEesnd5tCu33cHd2LGr9wigR2jUtjYrVNPAN7VG+K7q5LbIYHI16w==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-query/-/node-opcua-service-query-2.175.1.tgz",
+      "integrity": "sha512-Gdb1ZYwqlZfn5ssud+L9QQMMbgeBBMZOSAyKIAw4yKHem+cNejQ4Q9C5lEFve6DgSl0BVYZf2tilH5/VIXujBQ==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-service-browse": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-service-subscription": "2.63.2",
-        "node-opcua-service-translate-browse-path": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-service-read": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-read/-/node-opcua-service-read-2.63.2.tgz",
-      "integrity": "sha512-a+mXiptPfQQ7p55UU7qAgZU1BPAEJqxv/UPk77wQCdczwcD01K6R9OCILW2Aes9eX0S6fn1K9IR113296DWDbA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-read/-/node-opcua-service-read-2.175.1.tgz",
+      "integrity": "sha512-JzG3swpUETA4q5SdLXK7zIP7UJQnFbIz9mSXV+WkYuSNk9MvvdgIya2/VSsGZRA1SBWa3zRmLVlW+4t2/rwaXA==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-service-secure-channel": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-service-register-node": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-register-node/-/node-opcua-service-register-node-2.63.2.tgz",
-      "integrity": "sha512-nsH0Cfpc6kHLd4W2F/F9wmPjV5aNt/9H/vNrmhLf/1+koc6uYpLNaLZYHuGSCW78ah9ICfWyBxOSKWZWtYOLDQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-register-node/-/node-opcua-service-register-node-2.175.1.tgz",
+      "integrity": "sha512-tMW60af3FeFkW9yzWTfBMsJSBBT06E6132PcRgvXq5pKYhCi2z0ZjJz2Tref/wRlSvIFn+i1+JsBT+rwAyfK5Q==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-service-secure-channel": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-secure-channel/-/node-opcua-service-secure-channel-2.63.2.tgz",
-      "integrity": "sha512-te9Sn3jvmKRUVR9cfuoBw+o0w5f4z68GWMu2wcEqZbGP1+QedUUFRFMh4OgdECdiD4mXatxXPASuIoAVITYOzQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-secure-channel/-/node-opcua-service-secure-channel-2.175.1.tgz",
+      "integrity": "sha512-anECfPKt6l94xylD+GgXOYe3pF5bJ/+FBcpiBpN7tuYP60OASkJWCB5Kd3Le2T3wPmaWWBHsnmImo7RGWCMMnA==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-service-session": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-session/-/node-opcua-service-session-2.63.2.tgz",
-      "integrity": "sha512-kwbSWm5aDTAkiZ3IjzZtUqf5qL8j02E+Gdb1dUiJplgEs6TwW7NiEiK5btKABe+fPfY3vcqWeX6m8mOEia4IhA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-session/-/node-opcua-service-session-2.175.1.tgz",
+      "integrity": "sha512-9qM1FSWG1/6KuExWI/NyOej8dLo/gwf6+9JsyOl2uFdipNaeVJVhwCHkl6EHhii0lqG1D3QCtHV/VOGkiRweDQ==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-endpoints": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-service-subscription": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-subscription/-/node-opcua-service-subscription-2.63.2.tgz",
-      "integrity": "sha512-0EaLSaJGRG4KN/pcQoqFkPfGpEGxxTy+id7LybFWoMYoWx2599iCaJePlNZ72SbuJwhngc5mEOckY28edyXPjA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-subscription/-/node-opcua-service-subscription-2.175.1.tgz",
+      "integrity": "sha512-fOKq90qjNiAce9j4h0jGbcwguYlVoqbjPJzNy8d2XCmOCnmlfY3SPHDjO2iSMLJkFpWzgM9Gj/hEdUnSzW1/TA==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-filter": "2.63.2",
-        "node-opcua-service-read": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-types": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-service-translate-browse-path": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-translate-browse-path/-/node-opcua-service-translate-browse-path-2.63.2.tgz",
-      "integrity": "sha512-lTOo7Ywg8flHtVWpn+TvLWIIwzYg+zy+FbLxjGfIntyzpv/8YwnUrOx2CRK8DTwG+u+pUngAPgTKSm+21IP1EA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-translate-browse-path/-/node-opcua-service-translate-browse-path-2.175.1.tgz",
+      "integrity": "sha512-3TjSoNEusC68k4G4zjpQftYalMjkIxCbeI74iSxeADvzcSXD5OF+0y8NmEcXHJubmcQhO7gYbvxf0PznvpvsbA==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-service-write": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-write/-/node-opcua-service-write-2.63.2.tgz",
-      "integrity": "sha512-Gib+m5bNOLNQiCLjY29Gw2qY7SOH2cxUnDoXmcvzCQG74vh/WPAOBZvk6GbqHB1cmdISySZH9Dcbwc3V/DS+/g==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-service-write/-/node-opcua-service-write-2.175.1.tgz",
+      "integrity": "sha512-M7IS2wGPVOJbjG8MadfVBtang5cOESiOlqjMItqA+bqjISIYj2jLLl4ufIstyBKuEvy1uoV4pgbPaoDLdwrTlA==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-service-secure-channel": "2.63.2",
-        "node-opcua-types": "2.63.2"
+        "node-opcua-types": "2.175.1"
       }
     },
     "node-opcua-status-code": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-status-code/-/node-opcua-status-code-2.63.2.tgz",
-      "integrity": "sha512-T3nQHBKRTznwKFx7UPkxs/JccIKVf9u21im9IUt+OOpJ6ZhRFGYBPPs+/xSL9jrWrkE0Do9w1c5vrxNzILV0Iw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-status-code/-/node-opcua-status-code-2.175.1.tgz",
+      "integrity": "sha512-2+kDiVBIz/8Idzf3MohENlGPuenjoQGQsEKudqB1EMFIhVsUvGHTR6gumn3M7PucOb+zmxUGFBt8aDfioDWqLQ==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1"
       }
     },
     "node-opcua-transport": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-transport/-/node-opcua-transport-2.63.2.tgz",
-      "integrity": "sha512-xZsjTbt8I8QsXTM8LqDEcKYy2hNiYxg+50MK6lVYysnSJr/r5wJWokh3R6Kys9vVfuVIeJ/HSzTTF/Lxlt25rQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-transport/-/node-opcua-transport-2.175.1.tgz",
+      "integrity": "sha512-hy3BvjYmQ1WSoTzRPAGvo0wOzPTadgS1QBmSKDaj7EPgptyhcRUVYlSQ0PhtLxUfIN+yvyCNi+X+sd4P//ZN9w==",
       "requires": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-chunkmanager": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-object-registry": "2.63.2",
-        "node-opcua-packet-assembler": "2.63.0",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-types": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-buffer-utils": "2.175.1",
+        "node-opcua-chunkmanager": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-object-registry": "2.175.1",
+        "node-opcua-packet-assembler": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node-opcua-types": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-types/-/node-opcua-types-2.63.2.tgz",
-      "integrity": "sha512-/cqFFftZw18bYRZkp7DFKeB+gQeuU6hWjdKyf5ssxiVMJOqhug80o5qeq6b3kFssdVw4L9wQ5DIyK3T7lwKQlw==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-types/-/node-opcua-types-2.175.1.tgz",
+      "integrity": "sha512-ONdJ5LGqKTHaRWGsqHgzpcA3lK/YaHOKf4N9x+lheERZAuYUtAZ0GGqRH4fk+OlZV9oLEtSTx2MsR7rp6FaSYw==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-binary-stream": "2.63.2",
-        "node-opcua-buffer-utils": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-data-value": "2.63.2",
-        "node-opcua-date-time": "2.63.2",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-generator": "2.63.2",
-        "node-opcua-guid": "2.63.0",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-numeric-range": "2.63.2",
-        "node-opcua-packet-analyzer": "2.63.2",
-        "node-opcua-schemas": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-utils": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-data-value": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-extension-object": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-numeric-range": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-utils": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-utils/-/node-opcua-utils-2.63.2.tgz",
-      "integrity": "sha512-BAAfnxkYBFkxIyVr34paG5gyLYQJtKYyOj3RqOMwJEY2PMgITMxAJWGZh+NfsFPniczH+wgkooHw6qVOqEygxA==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-utils/-/node-opcua-utils-2.175.1.tgz",
+      "integrity": "sha512-10NAnKsRN2hrMg4dy4hFunx4eUfP1YnW84SFY7gD39piHPENdwDL83rCaYfnD02TrZOF1noWV6gLbMw2xKOJzg==",
       "requires": {
         "chalk": "4.1.2",
-        "node-opcua-assert": "2.63.0"
+        "node-opcua-assert": "2.175.1"
       }
     },
     "node-opcua-variant": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-variant/-/node-opcua-variant-2.63.2.tgz",
-      "integrity": "sha512-gd1cSz4MO1yYnMpx7qKavUA9h8y8Io4AQCCeVqyKcM7kP0JY08LnuGW37gnkhaVWj3CM1Zf4qswTGNxZs6vMdQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-variant/-/node-opcua-variant-2.175.1.tgz",
+      "integrity": "sha512-UgIA8n+BptK7GzispdKrxumKE/qSV3IgpoxkzVgx8qrXCfYH6No2/1HR0gaO5oAj679hsrpC1WFn8bijvNRmdg==",
       "requires": {
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-basic-types": "2.63.2",
-        "node-opcua-data-model": "2.63.2",
-        "node-opcua-enum": "2.63.2",
-        "node-opcua-extension-object": "2.63.2",
-        "node-opcua-factory": "2.63.2",
-        "node-opcua-nodeid": "2.63.2",
-        "node-opcua-utils": "2.63.2"
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-basic-types": "2.175.1",
+        "node-opcua-binary-stream": "2.175.1",
+        "node-opcua-data-model": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-enum": "2.175.1",
+        "node-opcua-factory": "2.175.1",
+        "node-opcua-nodeid": "2.175.1",
+        "node-opcua-utils": "2.175.1"
       }
     },
     "node-opcua-vendor-diagnostic": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-vendor-diagnostic/-/node-opcua-vendor-diagnostic-2.63.2.tgz",
-      "integrity": "sha512-O7Ziq4nmt7Fjy+gUXSCtcvJQkVmiFTGf+05K0EQZ0eEl1M6SBMwQ+BrpghRmxI/6Hi4Il3i4JLyDWVPgOfepmg==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-vendor-diagnostic/-/node-opcua-vendor-diagnostic-2.175.1.tgz",
+      "integrity": "sha512-FAPYgkt/3REq5P+YBZerY3zcIdtB4YWClmfzGqNTo6Qbteqtje11jhSeIATtL0tiPoM+5raO87I+AZ/isktqiw==",
       "requires": {
         "humanize": "0.0.9",
-        "node-opcua-address-space": "2.63.2",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-constants": "2.62.7",
-        "node-opcua-server": "2.63.2",
-        "node-opcua-status-code": "2.63.2",
-        "node-opcua-variant": "2.63.2"
+        "node-opcua-address-space": "2.175.1",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-constants": "2.175.1",
+        "node-opcua-debug": "2.175.1",
+        "node-opcua-server": "2.175.1",
+        "node-opcua-status-code": "2.175.1",
+        "node-opcua-variant": "2.175.1"
       }
     },
     "node-opcua-xml2json": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/node-opcua-xml2json/-/node-opcua-xml2json-2.63.2.tgz",
-      "integrity": "sha512-oY1LFaYBswctkkxPvi0cfPvyY70qMtLgK/WMjVoRSNQ1r1cN/4oU9xl7kSKcRdHskOLZSm88EkeyekcHbQQBBQ==",
+      "version": "2.175.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/node-opcua-xml2json/-/node-opcua-xml2json-2.175.1.tgz",
+      "integrity": "sha512-EBYg27WlNS2LqjVE2ojOngFDKnZ2/mXpuzBH3GJA3y9noI3M3pbfsJpsNyJ773//0vSO0gYZcqCSG1ApSPlXZw==",
       "requires": {
-        "bomstrip": "^0.1.4",
-        "ltx": "^3.0.0",
-        "node-opcua-assert": "2.63.0",
-        "node-opcua-debug": "2.63.2",
-        "node-opcua-utils": "2.63.2",
+        "node-opcua-assert": "2.175.1",
+        "node-opcua-utils": "2.175.1",
         "xml-writer": "^1.7.0"
       }
     },
@@ -11179,12 +10123,6 @@
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       }
-    },
-    "normalize-path": {
-      "version": "3.0.0"
-    },
-    "normalize-url": {
-      "version": "4.5.1"
     },
     "npm": {
       "version": "11.12.1",
@@ -12451,28 +11389,6 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
     },
-    "object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
     "onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -12481,11 +11397,6 @@
       "requires": {
         "mimic-fn": "^4.0.0"
       }
-    },
-    "p-cancelable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
     },
     "p-each-series": {
       "version": "3.0.0",
@@ -12534,24 +11445,6 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
       "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
       "dev": true
-    },
-    "package-json": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
-      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
-      "requires": {
-        "got": "^9.6.0",
-        "registry-auth-token": "^4.0.0",
-        "registry-url": "^5.0.0",
-        "semver": "^6.2.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -12624,8 +11517,8 @@
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "picocolors": {
       "version": "1.1.1",
@@ -12636,7 +11529,8 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -12729,13 +11623,8 @@
     },
     "precond": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
-    },
-    "prepend-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ=="
     },
     "pretty-ms": {
       "version": "9.3.0",
@@ -12752,38 +11641,30 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
-    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+    "pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "tslib": "^2.8.1"
       }
     },
-    "pupa": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
-      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
-      "requires": {
-        "escape-goat": "^2.0.0"
-      }
+    "pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="
     },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -12794,7 +11675,8 @@
         "ini": {
           "version": "1.3.8",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+          "dev": true
         }
       }
     },
@@ -12854,42 +11736,20 @@
       }
     },
     "readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
+      "version": "4.1.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
     },
-    "regexp.prototype.flags": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
-    },
-    "registry-auth-token": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
-      "requires": {
-        "rc": "^1.2.8"
-      }
-    },
-    "registry-url": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
-      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
-      "requires": {
-        "rc": "^1.2.8"
-      }
+    "reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
     },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "resolve-from": {
       "version": "5.0.0",
@@ -12897,22 +11757,9 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
-    "responselike": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-      "requires": {
-        "lowercase-keys": "^1.0.0"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semantic-release": {
@@ -13105,35 +11952,15 @@
       }
     },
     "semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
-    },
-    "semver-diff": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
-      "requires": {
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
+      "version": "7.8.5",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="
     },
     "semver-regex": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
       "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
       "dev": true
-    },
-    "set-prototype-of": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-prototype-of/-/set-prototype-of-1.0.0.tgz",
-      "integrity": "sha1-gCIdbaDsaFEd3HQ5CXV60UT8Hf0="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -13149,11 +11976,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
     },
     "signale": {
       "version": "1.4.0",
@@ -13281,9 +12103,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "version": "1.18.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -13294,6 +12116,18 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      }
+    },
+    "sterfive-bonjour-service": {
+      "version": "1.1.4",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/sterfive-bonjour-service/-/sterfive-bonjour-service-1.1.4.tgz",
+      "integrity": "sha512-QqDpnBb3KLD6ytdY2KSxsynw1jJAvzfOloQt83GQNXO6CGf84ZY+37tpOEZo1FzgUkFiVsL7pYyg71olDppI/w==",
+      "requires": {
+        "@types/multicast-dns": "^7.2.1",
+        "array-flatten": "^2.1.2",
+        "dns-equal": "^1.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.4"
       }
     },
     "stream-combiner2": {
@@ -13338,6 +12172,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -13348,6 +12183,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -13367,7 +12203,8 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "super-regex": {
       "version": "1.1.0",
@@ -13396,6 +12233,15 @@
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
+      }
+    },
+    "table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "requires": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
       }
     },
     "tagged-tag": {
@@ -13466,6 +12312,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "requires": {
         "any-promise": "^1.0.0"
       }
@@ -13479,9 +12326,14 @@
         "thenify": ">= 3.1.0 < 4"
       }
     },
+    "thenify-ex": {
+      "version": "4.4.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/thenify-ex/-/thenify-ex-4.4.0.tgz",
+      "integrity": "sha512-YHA/2DlY1vWpqGLCc7BzdT9aTrqyHCbsX5J3zbW68LLeD4RPwd+2tMEWshMP+27ikuTnaeKbFDmjqc7fKWmDew=="
+    },
     "thunky": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
     "time-span": {
@@ -13518,15 +12370,11 @@
         }
       }
     },
-    "to-readable-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
-    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -13537,15 +12385,36 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
+    "tslib": {
+      "version": "2.8.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "requires": {
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "type-fest": {
       "version": "5.5.0",
@@ -13556,19 +12425,16 @@
         "tagged-tag": "^1.0.0"
       }
     },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.9.3",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
+    },
+    "typical": {
+      "version": "7.3.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw=="
     },
     "uglify-js": {
       "version": "3.19.3",
@@ -13577,16 +12443,16 @@
       "dev": true,
       "optional": true
     },
-    "underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
-    },
     "undici": {
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
       "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "unicode-emoji-modifier-base": {
       "version": "1.0.0",
@@ -13600,14 +12466,6 @@
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true
     },
-    "unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "requires": {
-        "crypto-random-string": "^2.0.0"
-      }
-    },
     "universal-user-agent": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
@@ -13620,40 +12478,11 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true
     },
-    "update-notifier": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
-      "integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
-      "requires": {
-        "boxen": "^5.0.0",
-        "chalk": "^4.1.0",
-        "configstore": "^5.0.1",
-        "has-yarn": "^2.1.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.4.0",
-        "is-npm": "^5.0.0",
-        "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.1.0",
-        "pupa": "^2.1.1",
-        "semver": "^7.3.4",
-        "semver-diff": "^3.1.1",
-        "xdg-basedir": "^4.0.0"
-      }
-    },
     "url-join": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
       "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
       "dev": true
-    },
-    "url-parse-lax": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-      "requires": {
-        "prepend-http": "^2.0.0"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -13677,13 +12506,16 @@
       "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
       "dev": true
     },
-    "wget-improved": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/wget-improved/-/wget-improved-3.2.1.tgz",
-      "integrity": "sha512-bZmRufYav/OFRdS8LerCbzP3b/L8tjRwqap6NhqcvEAfZrBMFwqjtFzbVk2gutEWdG78WKJgIn9yveI+ENQSlA==",
+    "webcrypto-core": {
+      "version": "1.9.2",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+      "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
       "requires": {
-        "minimist": "1.2.5",
-        "tunnel": "0.0.6"
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "which": {
@@ -13695,44 +12527,26 @@
         "isexe": "^2.0.0"
       }
     },
-    "widest-line": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-      "requires": {
-        "string-width": "^4.0.0"
-      }
-    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
+    "wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg=="
+    },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "requires": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
       }
     },
     "ws": {
@@ -13741,15 +12555,10 @@
       "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
       "requires": {}
     },
-    "xdg-basedir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
-    },
     "xml-writer": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/xml-writer/-/xml-writer-1.7.0.tgz",
-      "integrity": "sha1-t28dWRwWomNOvbcDx729D9aBkGU="
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/xml-writer/-/xml-writer-1.7.0.tgz",
+      "integrity": "sha512-elFVMRiV5jb59fbc87zzVa0C01QLBEWP909mRuWqFqrYC5wNTH5QW4AaKMNv7d6zAsuOulkD7wnztZNLQW0Nfg=="
     },
     "xtend": {
       "version": "4.0.2",
@@ -13760,34 +12569,21 @@
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-    },
-    "yargs": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
-      "integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
-      "requires": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      }
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
     },
     "yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
     },
     "yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "version": "3.4.0",
+      "resolved": "https://npm.jfrog.engel.int:443/artifactory/api/npm/cc-npm-virtual/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
       }
     },
     "yoctocolors": {

--- a/package.json
+++ b/package.json
@@ -27,15 +27,16 @@
   "homepage": "https://github.com/demike/wsopcua-test-server#readme",
   "dependencies": {
     "chalk": "^4.1.2",
-    "node-opcua": "~2.63.2",
-    "node-opcua-crypto": "~1.7.5",
+    "node-opcua": "^2.175.1",
+    "node-opcua-address-space-for-conformance-testing": "^2.175.1",
+    "node-opcua-crypto": "^5.3.6",
     "ws": "^8.4.2"
   },
   "devDependencies": {
-    "@types/node": "^17.0.14",
-    "@types/ws": "^7.2.7",
+    "@types/node": "^20.0.0",
+    "@types/ws": "^8.5.0",
     "semantic-release": "^25.0.3",
-    "typescript": "^4.5.5"
+    "typescript": "^5.6.0"
   },
   "bin": {
     "wsopcua-test-server": "./dist/index.js"

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -6,7 +6,6 @@ import {
   DataType,
   Namespace,
   NodeIdLike,
-  readNodeSet2XmlFile,
   StatusCodes,
   Variant,
   VariantArrayType,
@@ -15,6 +14,7 @@ import { NodeSetLoader } from "node-opcua-address-space/dist/source/loader/load_
 import { nodesets } from "node-opcua-nodesets";
 import { startTestServer } from "./test-server";
 import { EventEmitter } from "events";
+import { promises as fsPromises } from "fs";
 
 interface UANamespace extends Namespace {
   _nodeid_index: { [key: string]: BaseNode };
@@ -193,47 +193,42 @@ export class Controller extends EventEmitter {
     return index;
   }
 
-  public loadNamespace(namespaceUri: string, index: number) {
+  public async loadNamespace(namespaceUri: string, index: number) {
     const addressSpace = this.testServer?.engine.addressSpace; // AddressSpace.create();
     if (!addressSpace) {
       return;
     }
 
     const loader = new NodeSetLoader(addressSpace as any);
-    readNodeSet2XmlFile(
-      this.nodesetMap.get(namespaceUri) as string,
-      (err, xmlFile) => {
-        if (err) {
-          console.error(err);
-          return;
-        }
-        if (!xmlFile) {
-          return;
-        }
-        loader.addNodeSet(xmlFile, (err) => {
-          if (err) {
-            console.error(err);
-          }
+    try {
+      // node-opcua removed the public `readNodeSet2XmlFile` helper and
+      // `NodeSetLoader.addNodeSet(xml, cb)` is now `addNodeSetAsync(xml)`.
+      const xmlFile = await fsPromises.readFile(
+        this.nodesetMap.get(namespaceUri) as string,
+        "utf-8"
+      );
+      await loader.addNodeSetAsync(xmlFile);
+    } catch (err) {
+      console.error(err);
+      return;
+    }
 
-          const nsarray = addressSpace.getNamespaceArray();
+    const nsarray = addressSpace.getNamespaceArray();
 
-          const newNamespace = nsarray.pop()!;
-          addressSpace.getNamespaceArray().splice(index, 0, newNamespace);
+    const newNamespace = nsarray.pop()!;
+    addressSpace.getNamespaceArray().splice(index, 0, newNamespace);
 
-          newNamespace.index = index;
+    newNamespace.index = index;
 
-          (addressSpace as any).suspendBackReference = false;
-          const nodes: BaseNode[] = Object.values(
-            (newNamespace as any)._nodeid_index
-          );
-          for (const node of nodes) {
-            node.propagate_back_references();
-          }
-          for (const node of nodes) {
-            node.install_extra_properties();
-          }
-        });
-      }
+    (addressSpace as any).suspendBackReference = false;
+    const nodes: BaseNode[] = Object.values(
+      (newNamespace as any)._nodeid_index
     );
+    for (const node of nodes) {
+      node.propagate_back_references();
+    }
+    for (const node of nodes) {
+      node.install_extra_properties();
+    }
   }
 }

--- a/src/node-manager.ts
+++ b/src/node-manager.ts
@@ -1,6 +1,5 @@
 import {
   AccessLevelFlag,
-  build_address_space_for_conformance_testing,
   coerceNodeId,
   DataType,
   ExpandedNodeId,
@@ -9,6 +8,8 @@ import {
   StatusCodes,
   Variant,
 } from "node-opcua";
+// No longer re-exported from the "node-opcua" barrel; import from its package.
+import { build_address_space_for_conformance_testing } from "node-opcua-address-space-for-conformance-testing";
 import { WsOPCUAServer } from "./ws/ws-opcua-server";
 
 export class NodeManager {

--- a/src/user-manager.ts
+++ b/src/user-manager.ts
@@ -1,7 +1,10 @@
-import { IUserManager, ServerSession, UserManagerOptions, ValidUserFunc } from "node-opcua";
+import { IUserManagerEx } from "node-opcua";
 
 
-export class UserManager implements UserManagerOptions {
+// node-opcua's `UserManagerOptions` is now a union type
+// (`IUserManagerEx | UAUserManagerBase`) which cannot be `implements`-ed.
+// We implement the plain object variant instead.
+export class UserManager implements IUserManagerEx {
 
     private users: {[key: string] : string} = {
         "john": "john_pw",

--- a/src/ws/server-endpoint.ts
+++ b/src/ws/server-endpoint.ts
@@ -10,7 +10,6 @@ import {
   SecurityPolicy,
   ServerSecureChannelLayer,
 } from "node-opcua";
-import { toPem } from "node-opcua-crypto";
 import * as ws from "ws";
 import * as https from "https";
 import { WebSocketSocketWrapper } from "./websocket-socket-wrapper";
@@ -45,6 +44,18 @@ export enum TransportType {
   TCP,
   WEBSOCKET,
   WEBSOCKET_SECURE,
+}
+
+/**
+ * Wrap a DER-encoded buffer in a PEM envelope.
+ *
+ * node-opcua-crypto v5 is an ESM-only package, so its `toPem` helper cannot be
+ * `require`d from this CommonJS module. Since the conversion is a plain base64
+ * re-encoding, we inline it here to avoid pulling in the ESM dependency.
+ */
+function derToPem(der: Buffer | Uint8Array, label: string): string {
+  const base64 = Buffer.from(der).toString("base64").replace(/(.{64})/g, "$1\n");
+  return `-----BEGIN ${label}-----\n${base64}\n-----END ${label}-----\n`;
 }
 
 export interface OPCUAWsServerEndpointOptions
@@ -178,7 +189,7 @@ export class OPCUAWsServerEndPoint extends OPCUAServerEndPoint {
   public addEndpointDescription(
     securityMode: MessageSecurityMode,
     securityPolicy: SecurityPolicy,
-    options?: EndpointDescriptionParams
+    options: EndpointDescriptionParams
   ): void {
     super.addEndpointDescription(securityMode, securityPolicy, options);
     const endpoints = this.endpointDescriptions();
@@ -195,10 +206,15 @@ export class OPCUAWsServerEndPoint extends OPCUAServerEndPoint {
 
 export class OPCUAWsSecureServerEndPoint extends OPCUAWsServerEndPoint {
   protected createWSServer(): ws.Server {
-    const pemCert = toPem(this.getCertificate(), "CERTIFICATE");
+    const pemCert = derToPem(this.getCertificate(), "CERTIFICATE");
+    // node-opcua-crypto v5 wraps the private key in an opaque
+    // `{ hidden: string | KeyObject }` object instead of returning a PEM
+    // string. Both a PEM string and a Node KeyObject are accepted by
+    // https.createServer as `key`, so we hand over the wrapped value.
+    const privateKey = (this.getPrivateKey() as unknown as { hidden: string | Object }).hidden;
     const httpServer = https.createServer({
       cert: pemCert,
-      key: this.getPrivateKey(),
+      key: privateKey as any,
     });
     const wsserver = new ws.Server({
       // port: this.port,

--- a/src/ws/websocket-socket-wrapper.ts
+++ b/src/ws/websocket-socket-wrapper.ts
@@ -1,7 +1,11 @@
 import { EventEmitter } from "ws";
 import * as net from 'net'
 
-export class WebSocketSocketWrapper implements net.Socket {
+// NOTE: This only implements the subset of net.Socket that node-opcua's
+// ServerTCP_transport actually consumes, so it deliberately does not
+// `implements net.Socket` (newer @types/node adds ~24 members we don't need).
+// It is handed to the endpoint's connection handler via an @ts-ignore cast.
+export class WebSocketSocketWrapper {
     write(str: Uint8Array | string, encoding?: string, cb?: (err?: Error) => void): boolean;
     write(str: Uint8Array | string, cb?: (err?: Error) => void): boolean;
     write(str: any, encoding?: any, cb?: any) {

--- a/src/ws/ws-opcua-server.ts
+++ b/src/ws/ws-opcua-server.ts
@@ -33,7 +33,11 @@ export class WsOPCUAServer extends OPCUAServer {
     }
   }
 
-  protected createEndpoint(
+  // NOTE: node-opcua's private OPCUAServer.createEndpoint lost its
+  // `transportType` parameter (now `(port, serverOptions)`), so we no longer
+  // override it directly. Instead we thread the transport type through our
+  // overridden createEndpointDescriptions into this dedicated factory.
+  protected createWsEndpoint(
     port1: number,
     transportType: TransportType,
     serverOptions: OPCUAServerOptions
@@ -43,6 +47,7 @@ export class WsOPCUAServer extends OPCUAServer {
 
     const endPoint = new transportConstructor({
       port: port1,
+      host: serverOptions.host,
 
       certificateManager: this.serverCertificateManager,
 
@@ -87,7 +92,7 @@ export class WsOPCUAServer extends OPCUAServer {
     endpointOptions.transportType =
       endpointOptions.transportType || TransportType.TCP;
 
-    const endPoint = this.createEndpoint(
+    const endPoint = this.createWsEndpoint(
       port,
       endpointOptions.transportType,
       serverOption

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,18 @@
 {
     "compilerOptions": {
-      "module": "commonjs",
-      "target": "es6",
+      // node16 so node-opcua 2.175's package.json "exports" subpaths
+      // (e.g. "node-opcua-crypto/web", "@peculiar/utils/bytes") resolve.
+      "module": "node16",
+      "target": "es2020",
       "declaration": true,
       "sourceMap": true,
       "outDir": "./dist",
-      "moduleResolution": "node",
+      "moduleResolution": "node16",
+      // node-opcua's shipped .d.ts assume a newer TS lib (generic
+      // EventEmitter, MapIterator, node:crypto default import); skip
+      // type-checking library declarations to avoid those upstream errors.
+      "skipLibCheck": true,
+      "esModuleInterop": true,
       "rootDir": "src",
      // "outFile": "./dist/ws-opcua.js"
      // "noImplicitAny": true


### PR DESCRIPTION
Bump node-opcua 2.63 -> 2.175 and reconcile the WebSocket transport overrides and related API drift with the new SDK.

- ws-opcua-server: base createEndpoint dropped its transportType param; route through a dedicated createWsEndpoint via createEndpointDescriptions
- server-endpoint: addEndpointDescription options now required; handle crypto v5 PrivateKey wrapper for https; inline DER->PEM (node-opcua-crypto is ESM-only and cannot be require()d from this CommonJS module)
- websocket-socket-wrapper: drop `implements net.Socket` (newer @types/node Socket grew members; wrapper is passed via @ts-ignore)
- controller: readNodeSet2XmlFile removed; loadNamespace is now async and uses NodeSetLoader.addNodeSetAsync
- node-manager: import build_address_space_for_conformance_testing from its own package (no longer on the node-opcua barrel)
- user-manager: UserManagerOptions is now a union; implement IUserManagerEx
- tsconfig: node16 module/resolution for exports-map subpaths, skipLibCheck, esModuleInterop, target es2020
- deps: add node-opcua-address-space-for-conformance-testing; bump dev toolchain (typescript 5.6+, @types/node 20, @types/ws 8)

There is no server-side transport factory in node-opcua (the transportFactory seam is client-side only), so the private-method override on the endpoint is retained.