### PR TITLE
feat(deps): update dependencies and support node-opcua 2.175 transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,16 +13,16 @@
         "node-opcua": "^2.175.1",
         "node-opcua-address-space-for-conformance-testing": "^2.175.1",
         "node-opcua-crypto": "^5.3.6",
-        "ws": "^8.4.2"
+        "ws": "^8.21.0"
       },
       "bin": {
         "wsopcua-test-server": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
-        "@types/ws": "^8.5.0",
-        "semantic-release": "^25.0.3",
-        "typescript": "^5.6.0"
+        "@types/node": "^24.0.0",
+        "@types/ws": "^8.18.1",
+        "semantic-release": "^25.0.7",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@actions/core": {
@@ -827,12 +827,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -6185,9 +6185,9 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
-      "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
+      "version": "25.0.7",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.7.tgz",
+      "integrity": "sha512-fFiUD7LNFI0TOGkc49WDHUX4GYKrOMDKct5ReSB1EJCZiPsPdbIPIJGys1xb2ILpK1v9JMsRkjJQgTRpbr7DgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7168,9 +7168,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
@@ -7310,15 +7310,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
-      "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -7985,11 +7986,11 @@
       }
     },
     "@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "requires": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "@types/normalize-package-data": {
@@ -11763,9 +11764,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semantic-release": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
-      "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
+      "version": "25.0.7",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.7.tgz",
+      "integrity": "sha512-fFiUD7LNFI0TOGkc49WDHUX4GYKrOMDKct5ReSB1EJCZiPsPdbIPIJGys1xb2ILpK1v9JMsRkjJQgTRpbr7DgQ==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^13.0.1",
@@ -12450,9 +12451,9 @@
       "dev": true
     },
     "undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
     },
     "unicode-emoji-modifier-base": {
       "version": "1.0.0",
@@ -12550,9 +12551,9 @@
       }
     },
     "ws": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
-      "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "requires": {}
     },
     "xml-writer": {

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "node-opcua": "^2.175.1",
     "node-opcua-address-space-for-conformance-testing": "^2.175.1",
     "node-opcua-crypto": "^5.3.6",
-    "ws": "^8.4.2"
+    "ws": "^8.21.0"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
-    "@types/ws": "^8.5.0",
-    "semantic-release": "^25.0.3",
-    "typescript": "^5.6.0"
+    "@types/node": "^24.0.0",
+    "@types/ws": "^8.18.1",
+    "semantic-release": "^25.0.7",
+    "typescript": "^5.9.3"
   },
   "bin": {
     "wsopcua-test-server": "./dist/index.js"

--- a/src/ws/websocket-socket-wrapper.ts
+++ b/src/ws/websocket-socket-wrapper.ts
@@ -44,7 +44,10 @@ export class WebSocketSocketWrapper {
         return this;
     }
     setKeepAlive(enable?: boolean, initialDelay?: number): this {
-        throw new Error('Method not implemented.');
+        // no-op: keep-alive is managed by the underlying WebSocket, not
+        // applicable here. node-opcua's ServerTCP_transport._install_socket
+        // calls this on connect, so it must not throw.
+        return this;
     }
     address() {
        return this.webSocket._socket.address();
@@ -166,8 +169,13 @@ export class WebSocketSocketWrapper {
     once(event: 'lookup', listener: (err: Error, address: string, family: string | number, host: string) => void): this;
     once(event: 'timeout', listener: () => void): this;
     once(event: any, listener: any) {
-        throw new Error('Method not implemented.');
-        return this;
+        // Auto-remove after the first invocation, delegating to the same
+        // event translation used by addListener.
+        const onceWrapper = (...args: any[]) => {
+            this.removeListener(event, onceWrapper);
+            listener(...args);
+        };
+        return this.addListener(event, onceWrapper);
     }
     prependListener(event: string, listener: (...args: any[]) => void): this;
     prependListener(event: 'close', listener: (had_error: boolean) => void): this;
@@ -179,8 +187,9 @@ export class WebSocketSocketWrapper {
     prependListener(event: 'lookup', listener: (err: Error, address: string, family: string | number, host: string) => void): this;
     prependListener(event: 'timeout', listener: () => void): this;
     prependListener(event: any, listener: any) {
-        throw new Error('Method not implemented.');
-        return this;
+        // WebSocket-backed socket: listener ordering is not significant here,
+        // so prepending is equivalent to a normal add.
+        return this.addListener(event, listener);
     }
 
     prependOnceListener(event: string, listener: (...args: any[]) => void): this;
@@ -193,8 +202,9 @@ export class WebSocketSocketWrapper {
     prependOnceListener(event: 'lookup', listener: (err: Error, address: string, family: string | number, host: string) => void): this;
     prependOnceListener(event: 'timeout', listener: () => void): this;
     prependOnceListener(event: any, listener: any) {
-        throw new Error('Method not implemented.');
-        return this;
+        // node-opcua's ServerTCP_transport uses this to install the one-time
+        // HEL "close" watcher; ordering is not significant here.
+        return this.once(event, listener);
     }
 
     get writable() {


### PR DESCRIPTION
Update runtime/dev dependencies to their latest compatible versions and fix the WebSocket socket wrapper against node-opcua 2.175's transport.

Dependency bumps:
- ws 8.4.2 -> 8.21.0
- @types/node 20 -> 24, @types/ws -> 8.18.1
- semantic-release 25.0.3 -> 25.0.7, typescript pinned to 5.9.x
- chalk held at 4 (v5 is ESM-only, breaks require() in this CJS project)
- typescript held at 5.9 (v7 is the native rewrite; out of scope here)

node-opcua 2.175's ServerTCP_transport calls setKeepAlive() and prependOnceListener() on the socket during connection setup. The WebSocketSocketWrapper threw "Method not implemented." for these, crashing every incoming WebSocket connection. Make setKeepAlive a no-op and route once/prependListener/prependOnceListener through the existing event translation. The OPC UA HEL/ACK handshake over opc.ws now succeeds.

package-lock resolved URLs kept on the public npm registry.